### PR TITLE
Address review feedback for output validation docs and demo tests

### DIFF
--- a/docs/additional-features/output-validation.mdx
+++ b/docs/additional-features/output-validation.mdx
@@ -39,7 +39,7 @@ In this example, `CustomerSupportAgent` checks the response for the presence of 
 
 #### Validation Attempts
 
-The `validation_attempts` parameter controls how many times an agent can retry when validation fails. **Default is 1** (no retries - validation failure raises an exception immediately).
+The `validation_attempts` parameter controls how many times an agent can retry when validation fails. **Default is 0** (no retries - validation failure raises an exception immediately).
 
 ```python
 from agency_swarm import Agent
@@ -63,7 +63,7 @@ class JSONAgent(Agent):
 **When to increase `validation_attempts`:**
 - **Format validation** (JSON, structured output): Use `validation_attempts=2-3`
 - **Content requirements** that agents can learn: Use `validation_attempts=2`
-- **Critical/security validation**: Keep default `validation_attempts=1` (fail-fast)
+- **Critical/security validation**: Keep default `validation_attempts=0` (fail-fast)
 
 ### Tool Validators
 

--- a/docs/additional-features/output-validation.mdx
+++ b/docs/additional-features/output-validation.mdx
@@ -39,7 +39,7 @@ In this example, `CustomerSupportAgent` checks the response for the presence of 
 
 #### Validation Attempts
 
-The `validation_attempts` parameter controls how many times an agent can retry when validation fails. **Default is 0** (no retries - validation failure raises an exception immediately).
+The `validation_attempts` parameter controls how many times an agent can retry when validation fails. **Default is 1** (one attempt, no retries). Set `validation_attempts=0` for immediate fail-fast behavior.
 
 ```python
 from agency_swarm import Agent
@@ -60,10 +60,10 @@ class JSONAgent(Agent):
             raise ValueError("Response must be valid JSON format.")
 ```
 
-**When to increase `validation_attempts`:**
+**When to adjust `validation_attempts`:**
 - **Format validation** (JSON, structured output): Use `validation_attempts=2-3`
 - **Content requirements** that agents can learn: Use `validation_attempts=2`
-- **Critical/security validation**: Keep default `validation_attempts=0` (fail-fast)
+- **Critical/security validation**: Use `validation_attempts=0` to disable retries
 
 ### Tool Validators
 

--- a/docs/additional-features/output-validation.mdx
+++ b/docs/additional-features/output-validation.mdx
@@ -39,7 +39,7 @@ In this example, `CustomerSupportAgent` checks the response for the presence of 
 
 #### Validation Attempts
 
-The `validation_attempts` parameter controls how many times an agent can retry when validation fails. **Default is 1** (one attempt, no retries). Set `validation_attempts=0` for immediate fail-fast behavior.
+The `validation_attempts` parameter controls how many times an agent can retry when validation fails. **Default is 1** (one retry). Set `validation_attempts=0` for immediate fail-fast behavior.
 
 ```python
 from agency_swarm import Agent

--- a/tests/demos/demo_response_validation.py
+++ b/tests/demos/demo_response_validation.py
@@ -176,11 +176,9 @@ def test_multiple_retry_attempts(results: ValidationTestResults):
     attempt_counter = {"count": 0}
 
     def format_validator(message: str) -> str:
-        """Require 'GREETING:' prefix and fail first attempt to exercise retries."""
+        """Require 'GREETING:' prefix and force one retry."""
         attempt_counter["count"] += 1
-        if attempt_counter["count"] == 1:
-            raise ValueError("Intentional failure to demonstrate retry logic")
-        if not message.upper().startswith("GREETING:"):
+        if not message.upper().startswith("GREETING:") or attempt_counter["count"] == 1:
             raise ValueError("Response must start with 'GREETING:' followed by your message")
         return message
 

--- a/tests/demos/demo_response_validation.py
+++ b/tests/demos/demo_response_validation.py
@@ -11,7 +11,6 @@ This comprehensive demo shows:
 
 import json
 import time
-from typing import Optional
 
 from agency_swarm import Agency, Agent
 
@@ -132,49 +131,11 @@ def test_json_format_validation(results: ValidationTestResults):
         results.add_result("JSON Format Validation", False, f"Exception during JSON validation: {str(e)[:100]}...")
 
 
-def test_content_policy_validation(results: ValidationTestResults):
-    """Test content policy enforcement."""
-    print("\n🧪 Test 3: Content Policy Validation")
-
-    forbidden_words = ["password", "secret", "confidential", "private"]
-
-    def content_policy_validator(message: str) -> str:
-        message_lower = message.lower()
-        for word in forbidden_words:
-            if word in message_lower:
-                raise ValueError(
-                    f"Response contains forbidden word '{word}'. Please rephrase without sensitive information."
-                )
-        return message
-
-    agent = Agent(
-        name="PolicyAgent",
-        description="Agent with content filtering",
-        instructions="Provide helpful information. If you receive policy warnings, rephrase to avoid sensitive terms.",
-        validation_attempts=2,
-    )
-    agent.response_validator = content_policy_validator
-
-    try:
-        agency = Agency([agent])
-        # Request something that might trigger policy violation
-        response = agency.get_completion("Tell me about access credentials and authentication.")
-
-        # Check if response avoids forbidden words
-        response_lower = response.lower()
-        violations = [word for word in forbidden_words if word in response_lower]
-
-        if not violations:
-            results.add_result("Content Policy Validation", True, f"No policy violations: {response[:50]}...")
-        else:
-            results.add_result("Content Policy Validation", False, f"Policy violations found: {violations}")
-    except Exception as e:
-        results.add_result("Content Policy Validation", False, f"Exception during policy validation: {str(e)[:100]}...")
 
 
 def test_validation_exception_raising(results: ValidationTestResults):
     """Test that exceptions are raised when retries are exhausted."""
-    print("\n🧪 Test 4: Exception Raising (Retries Exhausted)")
+    print("\n🧪 Test 3: Exception Raising (Retries Exhausted)")
 
     def strict_validator(message: str) -> str:
         # Require a very specific format that's unlikely to be used naturally
@@ -186,7 +147,7 @@ def test_validation_exception_raising(results: ValidationTestResults):
         name="StrictAgent",
         description="Agent with very strict validation",
         instructions="Always respond with simple, natural language. Do not use special prefixes or formatting.",
-        validation_attempts=1,  # No retries - should raise exception
+        validation_attempts=0,  # No retries - should raise exception
     )
     agent.response_validator = strict_validator
 
@@ -210,7 +171,7 @@ def test_validation_exception_raising(results: ValidationTestResults):
 
 def test_multiple_retry_attempts(results: ValidationTestResults):
     """Test multiple validation retry attempts."""
-    print("\n🧪 Test 5: Multiple Retry Attempts")
+    print("\n🧪 Test 4: Multiple Retry Attempts")
 
     def format_validator(message: str) -> str:
         if not message.upper().startswith("GREETING:"):
@@ -221,7 +182,7 @@ def test_multiple_retry_attempts(results: ValidationTestResults):
         name="FormatAgent",
         description="Agent that learns specific formatting",
         instructions="Respond naturally. If you receive formatting instructions, follow them exactly.",
-        validation_attempts=3,  # Allow multiple retries
+        validation_attempts=3,  # Allow multiple retries, though agent may succeed on first attempt
     )
     agent.response_validator = format_validator
 
@@ -257,7 +218,6 @@ def main():
     # Run all tests
     test_simple_keyword_validation(results)
     test_json_format_validation(results)
-    test_content_policy_validation(results)
     test_validation_exception_raising(results)
     test_multiple_retry_attempts(results)
 

--- a/tests/demos/demo_response_validation.py
+++ b/tests/demos/demo_response_validation.py
@@ -173,7 +173,13 @@ def test_multiple_retry_attempts(results: ValidationTestResults):
     """Test multiple validation retry attempts."""
     print("\n🧪 Test 4: Multiple Retry Attempts")
 
+    attempt_counter = {"count": 0}
+
     def format_validator(message: str) -> str:
+        """Require 'GREETING:' prefix and fail first attempt to exercise retries."""
+        attempt_counter["count"] += 1
+        if attempt_counter["count"] == 1:
+            raise ValueError("Intentional failure to demonstrate retry logic")
         if not message.upper().startswith("GREETING:"):
             raise ValueError("Response must start with 'GREETING:' followed by your message")
         return message


### PR DESCRIPTION
## Summary
- remove redundant content policy validation demo
- update example tests for sequential numbering and fail-fast logic
- clarify `validation_attempts` defaults in output validation docs

## Testing
- `pytest -q` *(fails: OpenAI API key not set)*

------
https://chatgpt.com/codex/tasks/task_e_68417ffeab0c8323b6fa56b18b20729c