### PR TITLE
Fix lazy initialization of OpenAI client

### DIFF
--- a/src/agency_swarm/agent.py
+++ b/src/agency_swarm/agent.py
@@ -392,8 +392,8 @@ class Agent(BaseAgent[MasterContext]):
 
         # --- Internal State Init ---
         self._openai_client = None
-        # Needed for file operations
-        self._openai_client_sync = OpenAI()
+        # Sync OpenAI client is lazily initialised when required
+        self._openai_client_sync = None
         self._subagents = {}
         # _thread_manager and _agency_instance are injected by Agency
 

--- a/src/agency_swarm/utils/agent_file_manager.py
+++ b/src/agency_swarm/utils/agent_file_manager.py
@@ -56,7 +56,7 @@ class AgentFileManager:
 
         try:
             with open(fpath, "rb") as f:
-                uploaded_file = self.agent._openai_client_sync.files.create(file=f, purpose="assistants")
+                uploaded_file = self.agent.client_sync.files.create(file=f, purpose="assistants")
             logger.info(
                 f"Agent {self.agent.name}: Successfully uploaded file {fpath.name} to OpenAI. "
                 f"File ID: {uploaded_file.id}"
@@ -81,7 +81,7 @@ class AgentFileManager:
             try:
                 # First, check if the vector store still exists.
                 try:
-                    self.agent._openai_client_sync.vector_stores.retrieve(
+                    self.agent.client_sync.vector_stores.retrieve(
                         vector_store_id=self.agent._associated_vector_store_id
                     )
                     logger.debug(
@@ -97,7 +97,7 @@ class AgentFileManager:
                     return uploaded_file.id  # File is uploaded, but association is skipped. Early exit.
 
                 # If VS exists, proceed to associate the file
-                self.agent._openai_client_sync.vector_stores.files.create(
+                self.agent.client_sync.vector_stores.files.create(
                     vector_store_id=self.agent._associated_vector_store_id, file_id=uploaded_file.id
                 )
                 logger.info(
@@ -171,7 +171,7 @@ class AgentFileManager:
                 f"Agent {self.agent.name}: files_folder '{folder_str}' does not specify a Vector Store ID "
                 "with '_vs_' suffix. Creating a new Vector Store."
             )
-            created_vs = self.agent._openai_client_sync.vector_stores.create(name=openai_vs_name)
+            created_vs = self.agent.client_sync.vector_stores.create(name=openai_vs_name)
             vs_id = created_vs.id
             new_folder_name = f"{folder_name}_{vs_id}"
             parent_dir = Path(base_path_str).parent


### PR DESCRIPTION
## Summary
- avoid eagerly instantiating OpenAI client
- revert unnecessary `OPENAI_API_KEY` checks in file handling
- always attempt file uploads and vector store creation

## Testing
- `pytest tests/test_agent_modules/test_agent_initialization.py::test_agent_initialization_with_all_parameters -q` *(fails: openai.OpenAIError)*


------
https://chatgpt.com/codex/tasks/task_e_6846d4f557d0832388f3f8240670171f