### PR TITLE
Implement agency factory callbacks

### DIFF
--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -1,0 +1,126 @@
+---
+title: "FastAPI Integration"
+description: "Serving your agencies and tools as APIs with FastAPI."
+icon: "server"
+---
+
+Agency Swarm supports serving your agencies and tools as production-ready HTTP APIs using [FastAPI](https://fastapi.tiangolo.com/). This enables you to integrate your agents with other services or connect them to web frontends.
+
+## Installation
+
+FastAPI integration is an **optional installation**. To install all required dependencies, run:
+
+```bash
+pip install agency-swarm[fastapi]
+```
+
+## Setting Up FastAPI Endpoints
+
+You can expose your agencies and tools as API endpoints using the `run_fastapi()` function.
+
+### Example: Create an API endpoint for a single agency using the instance method
+
+```python
+from agency_swarm.agency import Agency
+
+agency = Agency([ceo], name="test_agency")
+
+agency.run_fastapi()
+```
+
+You can also pass optional arguments:
+- `host` (default: `"0.0.0.0"`)
+- `port` (default: `8000`)
+- `app_token_env` (default: `"APP_TOKEN"`)
+
+This creates two endpoints:
+- `/test_agency/get_completion`
+- `/test_agency/get_completion_stream`
+
+Both endpoints accept parameters such as `message`, `recipient_agent`, `additional_instructions`, `message_files`, and more. You should also pass the previous `chat_history` dictionary (see hooks documentation for the exact format).
+Responses include a `response` field with the agent reply and a `chat_history` field
+containing the serialized conversation threads. The streaming endpoint sends
+`chat_history` as the final event once generation is complete.
+
+If the environment variable specified by `app_token_env` is set, a bearer token is required for all requests. Otherwise, authentication is disabled.
+
+### Example: Serving Multiple Agencies and Tools with Factory Functions
+
+Create factory functions in an `agency.py` file (or files) that build and return `Agency` instances. These factories should accept a `load_threads_callback` keyword argument so the integration can restore conversation history from each request. Import these factories in `main.py` and pass them to `run_fastapi` as a mapping:
+
+```python
+from pydantic import Field
+
+from agency_swarm.agency import Agency
+from agency_swarm.tools import BaseTool
+from agency_swarm.integrations.fastapi import run_fastapi
+from agency import create_agency_1, create_agency_2
+
+# Example tools
+class ExampleTool(BaseTool):
+    example_field: str = Field(..., description="Example input.")
+    def run(self):
+        return "Result of ExampleTool operation"
+
+class TestTool(BaseTool):
+    example_field: str = Field(..., description="Example input.")
+    def run(self):
+        return "Result of TestTool operation"
+
+run_fastapi(
+    agencies={
+        "agency_1": create_agency_1,
+        "agency_2": create_agency_2,
+    },
+    tools=[ExampleTool, TestTool],
+)
+```
+
+This launches endpoints:
+- `/agency_1/get_completion`
+- `/agency_1/get_completion_stream`
+- `/agency_2/get_completion`
+- `/agency_2/get_completion_stream`
+- `/tool/ExampleTool`
+- `/tool/TestTool`
+
+Inputs for tool endpoints follow their Pydantic schemas.
+
+---
+
+## API Usage Example
+
+You can interact with your agents and tools using HTTP requests. Here's an example using Python's `requests` library:
+
+```python
+import requests
+
+agency_url = "http://127.0.0.1:8000/agency_1/get_completion"
+payload = {
+    "message": "Hello",
+    "chat_history": {},  # send previous threads here
+}
+headers = {"Authorization": "Bearer 123"}
+
+agency_response = requests.post(agency_url, json=payload, headers=headers)
+print("Status code:", agency_response.status_code)
+print("Response:", agency_response.json())
+
+tool_url = "http://127.0.0.1:8000/tool/ExampleTool"
+payload = {"example_field": "test"}
+
+tool_response = requests.post(tool_url, json=payload, headers=headers)
+print("Status code:", tool_response.status_code)
+print("Response:", tool_response.json())
+```
+
+---
+
+## Endpoint Structure
+
+- **Agency Endpoints:**
+  - `/your_agency_name/get_completion` (POST)
+  - `/your_agency_name/get_completion_stream` (POST, streaming responses)
+- **Tool Endpoints:**
+  - `/tool/ToolClassName` (POST)
+

--- a/src/agency_swarm/agency.py
+++ b/src/agency_swarm/agency.py
@@ -565,12 +565,15 @@ class Agency:
             raise TypeError("recipient_agent must be an Agent instance or agent name string.")
 
     def run_fastapi(self, host: str = "0.0.0.0", port: int = 8000, app_token_env: str = "APP_TOKEN"):
-        """
-        Launch a FastAPI server exposing the agency's completion and streaming endpoints using the shared integrations.fastapi.run_fastapi utility.
-        """
+        """Serve this agency via the FastAPI integration."""
         from agency_swarm.integrations.fastapi import run_fastapi
 
-        run_fastapi(agencies=[self], host=host, port=port, app_token_env=app_token_env)
+        run_fastapi(
+            agencies={self.name or "agency": lambda **kwargs: self},
+            host=host,
+            port=port,
+            app_token_env=app_token_env,
+        )
 
     # --- Deprecated Methods ---
     async def _async_get_completion(
@@ -691,7 +694,6 @@ class Agency:
             # If we reach here, there's already a running loop
             # We need to create a new thread to run the async function
             import concurrent.futures
-            import threading
 
             def run_in_thread():
                 # Create new event loop in the thread

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from collections.abc import Callable
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -23,11 +24,11 @@ def get_verify_token(app_token):
 
 
 # Non‑streaming completion endpoint
-# TODO: change current agency to callable
-def make_response_endpoint(request_model, current_agency: Agency, verify_token):
+def make_response_endpoint(request_model, agency_factory: Callable[..., Agency], verify_token):
     async def handler(request: request_model, token: str = Depends(verify_token)):
-        # TODO: Init agency agency_instance = current_agency()
-        response = await current_agency.get_response(
+        load_callback = lambda: request.chat_history or {}
+        agency_instance = agency_factory(load_threads_callback=load_callback)
+        response = await agency_instance.get_response(
             message=request.message,
             recipient_agent=request.recipient_agent,
             additional_instructions=request.additional_instructions,
@@ -35,20 +36,24 @@ def make_response_endpoint(request_model, current_agency: Agency, verify_token):
             file_ids=request.file_ids,
             attachments=request.attachments,
         )
-        # TODO: extract history
-        # TODO: chat_history = agency_instance.thread_manager._thread
-        return {"response": response.final_output, "chat_history": "history placeholder"}
+        history = {
+            thread_id: {"items": thread.items, "metadata": thread.metadata}
+            for thread_id, thread in agency_instance.thread_manager._threads.items()
+        }
+        return {"response": response.final_output, "chat_history": history}
 
     return handler
 
 
 # Streaming SSE endpoint
-def make_stream_endpoint(request_model, current_agency: Agency, verify_token):
+def make_stream_endpoint(request_model, agency_factory: Callable[..., Agency], verify_token):
     async def handler(request: request_model, token: str = Depends(verify_token)):
-        # TODO: Init agency agency_instance = current_agency()
+        load_callback = lambda: request.chat_history or {}
+        agency_instance = agency_factory(load_threads_callback=load_callback)
+
         async def event_generator():
             try:
-                async for event in current_agency.get_response_stream(
+                async for event in agency_instance.get_response_stream(
                     message=request.message,
                     recipient_agent=request.recipient_agent,
                     additional_instructions=request.additional_instructions,
@@ -56,11 +61,7 @@ def make_stream_endpoint(request_model, current_agency: Agency, verify_token):
                     file_ids=request.file_ids,
                     attachments=request.attachments,
                 ):
-                    print("Yielding event:", event)
-                    # Try to serialize the event
-                    # TODO: add chat history to the output
                     try:
-                        # If event has a .model_dump() or .dict() method, use it
                         if hasattr(event, "model_dump"):
                             data = event.model_dump()
                         elif hasattr(event, "dict"):
@@ -74,6 +75,12 @@ def make_stream_endpoint(request_model, current_agency: Agency, verify_token):
                         yield "data: " + json.dumps({"error": f"Failed to serialize event: {e}"}) + "\n\n"
             except Exception as exc:
                 yield "data: " + json.dumps({"error": str(exc)}) + "\n\n"
+
+            history = {
+                thread_id: {"items": thread.items, "metadata": thread.metadata}
+                for thread_id, thread in agency_instance.thread_manager._threads.items()
+            }
+            yield "data: " + json.dumps({"chat_history": history}) + "\n\n"
 
         return StreamingResponse(
             event_generator(),
@@ -93,7 +100,6 @@ def make_tool_endpoint(tool, verify_token, context=None):
     async def handler(request: Request, token: str = Depends(verify_token)):
         try:
             data = await request.json()
-            print("data:", data)
             # If this is a FunctionTool (from @function_tool), use on_invoke_tool
             if hasattr(tool, "on_invoke_tool"):
                 # Ensure 'args' key is present for function tools
@@ -101,7 +107,6 @@ def make_tool_endpoint(tool, verify_token, context=None):
                     input_json = json.dumps({"args": data})
                 else:
                     input_json = json.dumps(data)
-                print("input_json:", input_json)
                 result = await tool.on_invoke_tool(context, input_json)
             elif isinstance(tool, type):
                 tool_instance = tool(**data)


### PR DESCRIPTION
## Summary
- document chat_history usage and factory callback requirement
- create agency instances with request chat history via load_threads_callback
- accept agency factory callables in `run_fastapi`
- expose single agency via lambda accepting kwargs

## Testing
- `make format` *(fails: E501 line too long and F403 imports)*
- `make lint` *(fails: 74 errors)*
- `make tests` *(fails: 54 failed, 66 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851bb4753a88323b756aa5c2d957fcc