### PR TITLE
Refactor FastAPI to use agency factories

### DIFF
--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -1,0 +1,77 @@
+---
+title: "FastAPI Integration"
+description: "Serve your agencies through FastAPI using factory functions."
+icon: "server"
+---
+
+Use `run_fastapi` to expose your agencies as REST endpoints. The function accepts
+a dictionary mapping URL-friendly names to *factory callables* that construct a
+fresh `Agency` instance for each request. The mapping keys become part of the
+endpoint path, so `{"company": create_agency}` results in `/company/get_completion`.
+Each factory should accept an optional `load_threads_callback` argument used to
+restore conversation history per request.
+
+```python
+# agency.py
+from agency_swarm import Agent, Agency
+
+# create your agents here
+
+def create_agency(load_threads_callback=None) -> Agency:
+    ceo = Agent(name="CEO", instructions="Lead the team")
+    dev = Agent(name="Developer", instructions="Write code")
+    return Agency(
+        ceo,
+        dev,
+        communication_flows=[(ceo, dev)],
+        load_threads_callback=load_threads_callback,
+    )
+```
+
+```python
+# main.py
+from agency_swarm.integrations.fastapi import run_fastapi
+from agency import create_agency
+
+if __name__ == "__main__":
+    run_fastapi({"company": create_agency})
+```
+
+If you manage multiple agency types, create a factory that selects by name:
+
+```python
+# agency.py
+def make_agency(name: str) -> Agency:
+    if name == "company":
+        return create_agency()
+    raise ValueError("Unknown agency")
+
+# main.py
+from agency_swarm.integrations.fastapi import run_fastapi
+from agency import make_agency
+
+run_fastapi({"company": lambda: make_agency("company")})
+```
+
+Each request initializes a fresh agency using your factory. Endpoints are created at `/company/get_completion` and `/company/get_completion_stream`.
+Provide the previous conversation history in the `chat_history` field of each request. Both endpoints return the updated history so you can persist it and send it back next time. For streaming requests the history is sent as the final event.
+
+Set an environment variable `APP_TOKEN` for basic bearer token authentication or override `app_token_env`.
+
+You can also include tools:
+
+```python
+from mytools import MyTool
+run_fastapi({"company": create_agency}, tools=[MyTool])
+```
+
+```python
+import requests
+
+history = {}
+payload = {"message": "Hello", "chat_history": history}
+resp = requests.post("http://127.0.0.1:8000/company/get_completion", json=payload)
+history = resp.json()["chat_history"]
+```
+
+Use `Agency.run_fastapi()` for quick testing when serving a single instance.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -109,7 +109,8 @@
               "additional-features/azure-openai",
               "additional-features/open-source-models",
               "additional-features/deployment-to-production",
-              "additional-features/observability"
+              "additional-features/observability",
+              "additional-features/fastapi-integration"
             ]
           },
           {

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1,11 +1,13 @@
 import asyncio
 import json
+from typing import Callable
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from agency_swarm.agency import Agency
+from agency_swarm.thread import ConversationThread
 
 
 def get_verify_token(app_token):
@@ -23,11 +25,25 @@ def get_verify_token(app_token):
 
 
 # Non‑streaming completion endpoint
-# TODO: change current agency to callable
-def make_response_endpoint(request_model, current_agency: Agency, verify_token):
+def _instantiate_agency(factory: Callable[..., Agency], history: dict | None) -> Agency:
+    """Create an Agency using the factory with optional thread history."""
+    history_dict = {tid: {"items": th.items, "metadata": th.metadata} for tid, th in (history or {}).items()}
+    try:
+        return factory(load_threads_callback=lambda: history_dict)
+    except TypeError:
+        agency = factory()
+        if history:
+            agency.thread_manager._threads = {
+                tid: ConversationThread(thread_id=tid, items=th.items, metadata=th.metadata)
+                for tid, th in history.items()
+            }
+        return agency
+
+
+def make_response_endpoint(request_model, agency_factory: Callable[..., Agency], verify_token):
     async def handler(request: request_model, token: str = Depends(verify_token)):
-        # TODO: Init agency agency_instance = current_agency()
-        response = await current_agency.get_response(
+        agency_instance = _instantiate_agency(agency_factory, request.chat_history)
+        response = await agency_instance.get_response(
             message=request.message,
             recipient_agent=request.recipient_agent,
             additional_instructions=request.additional_instructions,
@@ -35,20 +51,23 @@ def make_response_endpoint(request_model, current_agency: Agency, verify_token):
             file_ids=request.file_ids,
             attachments=request.attachments,
         )
-        # TODO: extract history
-        # TODO: chat_history = agency_instance.thread_manager._thread
-        return {"response": response.final_output, "chat_history": "history placeholder"}
+        history_data = {
+            tid: {"items": th.items, "metadata": th.metadata}
+            for tid, th in agency_instance.thread_manager._threads.items()
+        }
+        return {"response": response.final_output, "chat_history": history_data}
 
     return handler
 
 
 # Streaming SSE endpoint
-def make_stream_endpoint(request_model, current_agency: Agency, verify_token):
+def make_stream_endpoint(request_model, agency_factory: Callable[..., Agency], verify_token):
     async def handler(request: request_model, token: str = Depends(verify_token)):
-        # TODO: Init agency agency_instance = current_agency()
+        agency_instance = _instantiate_agency(agency_factory, request.chat_history)
+
         async def event_generator():
             try:
-                async for event in current_agency.get_response_stream(
+                async for event in agency_instance.get_response_stream(
                     message=request.message,
                     recipient_agent=request.recipient_agent,
                     additional_instructions=request.additional_instructions,
@@ -56,9 +75,7 @@ def make_stream_endpoint(request_model, current_agency: Agency, verify_token):
                     file_ids=request.file_ids,
                     attachments=request.attachments,
                 ):
-                    print("Yielding event:", event)
                     # Try to serialize the event
-                    # TODO: add chat history to the output
                     try:
                         # If event has a .model_dump() or .dict() method, use it
                         if hasattr(event, "model_dump"):
@@ -74,6 +91,13 @@ def make_stream_endpoint(request_model, current_agency: Agency, verify_token):
                         yield "data: " + json.dumps({"error": f"Failed to serialize event: {e}"}) + "\n\n"
             except Exception as exc:
                 yield "data: " + json.dumps({"error": str(exc)}) + "\n\n"
+            else:
+                # After streaming completes send the final chat history
+                history_data = {
+                    tid: {"items": th.items, "metadata": th.metadata}
+                    for tid, th in agency_instance.thread_manager._threads.items()
+                }
+                yield "data: " + json.dumps({"chat_history": history_data}) + "\n\n"
 
         return StreamingResponse(
             event_generator(),
@@ -93,7 +117,6 @@ def make_tool_endpoint(tool, verify_token, context=None):
     async def handler(request: Request, token: str = Depends(verify_token)):
         try:
             data = await request.json()
-            print("data:", data)
             # If this is a FunctionTool (from @function_tool), use on_invoke_tool
             if hasattr(tool, "on_invoke_tool"):
                 # Ensure 'args' key is present for function tools
@@ -101,7 +124,6 @@ def make_tool_endpoint(tool, verify_token, context=None):
                     input_json = json.dumps({"args": data})
                 else:
                     input_json = json.dumps(data)
-                print("input_json:", input_json)
                 result = await tool.on_invoke_tool(context, input_json)
             elif isinstance(tool, type):
                 tool_instance = tool(**data)


### PR DESCRIPTION
## Summary
- add `fastapi-integration` docs about using factories
- refactor FastAPI integration to accept callable agency factories
- return chat history from both response endpoints
- document factory mapping and refine function docstring

## Testing
- `pre-commit run --files docs/additional-features/fastapi-integration.mdx src/agency_swarm/integrations/fastapi.py src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py docs/docs.json`
- `pytest -q` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851bb3c249c8323be4ed03247877a50