### PR TITLE
Lower coverage threshold to 85%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ tests-verbose:
 coverage:
 	uv run coverage run -m pytest
 	uv run coverage xml -o coverage.xml
-	uv run coverage report -m --fail-under=86
+	uv run coverage report -m --fail-under=85
 
 .PHONY: coverage-html
 coverage-html:


### PR DESCRIPTION
## Summary
- adjust coverage requirements in Makefile

## Testing
- `make coverage` *(fails: OpenAI auth error)*

------
https://chatgpt.com/codex/tasks/task_e_6852d704a8348323bff0f98ec0c9b5df