### PR TITLE
Rename FastAPI endpoint to get_response

### DIFF
--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     run_fastapi({"company": create_agency})
 ```
 
-- The mapping key (here, `"company"`) becomes the endpoint path: `/company/get_completion` and `/company/get_completion_stream`.
+- The mapping key (here, `"company"`) becomes the endpoint path: `/company/get_response` and `/company/get_response_stream`.
 - Each request initializes a fresh agency using your factory.
 - Always pass the `load_threads_callback` argument through to the `Agency` constructor so chat history is restored per request.
 
@@ -121,7 +121,7 @@ import requests
 
 history = {}
 payload = {"message": "Hello", "chat_history": history}
-resp = requests.post("http://127.0.0.1:8000/company/get_completion", json=payload)
+resp = requests.post("http://127.0.0.1:8000/company/get_response", json=payload)
 history = resp.json()["chat_history"]
 ```
 
@@ -130,7 +130,7 @@ history = resp.json()["chat_history"]
 ## Endpoint Structure
 
 - **Agency Endpoints:**
-  - `/your_agency_name/get_completion` (POST)
-  - `/your_agency_name/get_completion_stream` (POST, streaming responses)
+  - `/your_agency_name/get_response` (POST)
+  - `/your_agency_name/get_response_stream` (POST, streaming responses)
 - **Tool Endpoints:**
   - `/tool/ToolClassName` (POST)

--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -72,10 +72,10 @@ from agency_swarm.integrations.fastapi import run_fastapi
 from agency import create_agency
 
 if __name__ == "__main__":
-    run_fastapi({"company": create_agency})
+    run_fastapi({"agency_name": create_agency})
 ```
 
-- The mapping key (here, `"company"`) becomes the endpoint path: `/company/get_response` and `/company/get_response_stream`.
+- The mapping key (here, `"agency_name"`) becomes the endpoint path: `/agency_name/get_response` and `/agency_name/get_response_stream`.
 - Each request initializes a fresh agency using your factory.
 - Always pass the `load_threads_callback` argument through to the `Agency` constructor so chat history is restored per request.
 
@@ -85,7 +85,7 @@ If you want to serve multiple agency types, you can use a selector function:
 ```python
 # agency.py
 def make_agency(name: str, load_threads_callback=None) -> Agency:
-    if name == "company":
+    if name == "agency_name":
         return create_agency(load_threads_callback=load_threads_callback)
     raise ValueError("Unknown agency")
 
@@ -93,7 +93,7 @@ def make_agency(name: str, load_threads_callback=None) -> Agency:
 from agency_swarm.integrations.fastapi import run_fastapi
 from agency import make_agency
 
-run_fastapi({"company": lambda load_threads_callback=None: make_agency("company", load_threads_callback)})
+run_fastapi({"agency_name": lambda load_threads_callback=None: make_agency("agency_name", load_threads_callback)})
 ```
 
 #### Including Tools
@@ -101,7 +101,7 @@ You can also expose tools as endpoints:
 
 ```python
 from mytools import MyTool
-run_fastapi({"company": create_agency}, tools=[MyTool])
+run_fastapi({"agency_name": create_agency}, tools=[MyTool])
 ```
 
 #### Tips & Gotchas
@@ -121,7 +121,7 @@ import requests
 
 history = {}
 payload = {"message": "Hello", "chat_history": history}
-resp = requests.post("http://127.0.0.1:8000/company/get_response", json=payload)
+resp = requests.post("http://127.0.0.1:8000/agency_name/get_response", json=payload)
 history = resp.json()["chat_history"]
 ```
 

--- a/src/agency_swarm/integrations/fastapi.py
+++ b/src/agency_swarm/integrations/fastapi.py
@@ -90,17 +90,17 @@ def run_fastapi(
             AgencyRequest = add_agent_validator(BaseRequest, AGENT_INSTANCES)
 
             app.add_api_route(
-                f"/{agency_name}/get_completion",
+                f"/{agency_name}/get_response",
                 make_response_endpoint(AgencyRequest, agency_factory, verify_token),
                 methods=["POST"],
             )
             app.add_api_route(
-                f"/{agency_name}/get_completion_stream",
+                f"/{agency_name}/get_response_stream",
                 make_stream_endpoint(AgencyRequest, agency_factory, verify_token),
                 methods=["POST"],
             )
-            endpoints.append(f"/{agency_name}/get_completion")
-            endpoints.append(f"/{agency_name}/get_completion_stream")
+            endpoints.append(f"/{agency_name}/get_response")
+            endpoints.append(f"/{agency_name}/get_response_stream")
 
     if tools:
         for tool in tools:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -23,7 +23,7 @@ def get_verify_token(app_token):
     return verify_token
 
 
-# Non‑streaming completion endpoint
+# Non‑streaming response endpoint
 def make_response_endpoint(request_model, agency_factory: Callable[..., Agency], verify_token):
     async def handler(request: request_model, token: str = Depends(verify_token)):
         if request.chat_history is not None:


### PR DESCRIPTION
## Summary
- rename `/get_completion` endpoints to `/get_response`
- update docs for FastAPI integration
- adjust comment in endpoint_handlers

## Testing
- `make tests` *(fails: OpenAI API key not set)*

------
https://chatgpt.com/codex/tasks/task_e_6852e5fe05a88323a70b5332e17ac568