### PR TITLE
Avoid mutable default list for cors_origins parameter

### DIFF
--- a/src/agency_swarm/integrations/fastapi.py
+++ b/src/agency_swarm/integrations/fastapi.py
@@ -17,7 +17,7 @@ def run_fastapi(
     port: int = 8000,
     app_token_env: str = "APP_TOKEN",
     return_app: bool = False,
-    cors_origins: list[str] = ["*"],
+    cors_origins: list[str] | None = None,
 ):
     """Launch a FastAPI server exposing endpoints for multiple agencies and tools.
 
@@ -60,6 +60,9 @@ def run_fastapi(
     verify_token = get_verify_token(app_token)
 
     app = FastAPI()
+
+    if cors_origins is None:
+        cors_origins = ["*"]
 
     app.add_middleware(
         CORSMiddleware,


### PR DESCRIPTION
## Summary
- avoid mutable default list for cors_origins parameter

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685319add5c88323b10a77f1c3a5b248