### PR TITLE
Add Responses streaming event mapping

### DIFF
--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -43,6 +43,11 @@ run_fastapi(
 Agency endpoints accept parameters such as `message`, `recipient_agent`, `additional_instructions` and `message_files`. You should also pass the previous `chat_history` dictionary (see hooks documentation for the exact format).
 Responses include a `response` field with the agent reply and a `chat_history` field containing the serialized conversation threads. The streaming endpoint sends `chat_history` as the final event once generation is complete.
 
+Streaming events now follow the new naming from the Responses API. If you were
+previously relying on the Assistants API event names, see the
+[Response Stream Event Mapping](./response-stream-event-mapping) table for the
+equivalent event types.
+
 If the environment variable specified by `app_token_env` is set, a bearer token is required for all requests. Otherwise, authentication is disabled.
 
 ### Example: Serving Multiple Agencies and Tools with Factory Functions

--- a/docs/additional-features/response-stream-event-mapping.mdx
+++ b/docs/additional-features/response-stream-event-mapping.mdx
@@ -1,0 +1,30 @@
+---
+title: "Response Stream Event Mapping"
+description: "Mapping of Assistants API streaming events to the new Responses API event names."
+icon: "arrows-turn-to-dots"
+---
+
+When migrating from the Assistants API to the Responses API, the names of the streaming
+Server‑Sent Events (SSE) changed. The table below summarizes the most common
+correspondence between old `AssistantStreamEvent` types and the new
+`ResponseStreamEvent` types.
+
+| Assistants API Event | Responses API Event |
+| -------------------- | ------------------ |
+| `thread.run.queued` | `response.queued` |
+| `thread.run.created` | `response.created` |
+| `thread.run.in_progress` | `response.in_progress` |
+| `thread.run.requires_action` | Specific `response.*_call` events (e.g. `response.mcp_call.in_progress`) |
+| `thread.run.completed` | `response.completed` |
+| `thread.run.failed` | `response.failed` |
+| `thread.run.cancelled` / `thread.run.expired` / `thread.run.incomplete` | `response.incomplete` |
+| `thread.message.created` | `response.output_item.added` |
+| `thread.message.delta` | `response.output_text.delta` |
+| `thread.message.completed` | `response.output_text.done` + `response.output_item.done` |
+| `thread.run.step.delta` | `response.function_call.arguments_delta` and other tool‑specific events |
+| `thread.run.step.completed` | `response.function_call.arguments_done` or `response.*_call.completed` |
+| `error` | `response.error` |
+
+The Responses API also introduces many additional events for reasoning summaries,
+file search, web search and image generation. See the OpenAI documentation for
+the full list of `ResponseStreamEvent` types.

--- a/docs/migration_guide.mdx
+++ b/docs/migration_guide.mdx
@@ -53,6 +53,7 @@ v0.x documentation is available at the current documentation site until v1.0 rea
 - **Modern Tool System**: `@function_tool` decorator replaces `BaseTool` classes for cleaner tool definitions
 - **Better Validation**: `output_guardrails` and `input_guardrails` replace the old `response_validator` system
 - **Real-time Streaming**: Improved streaming capabilities with async response handling
+- **Updated Stream Event Names**: Streaming events now use the Responses API nomenclature. See the [Response Stream Event Mapping](/additional-features/response-stream-event-mapping) for details.
 
 ## Why These Changes? (Architectural Context)
 


### PR DESCRIPTION
## Summary
- document mapping from Assistants event names to Responses event names
- mention the new names in FastAPI integration doc
- link to the mapping from migration guide

## Testing
- `make tests` *(fails: can't create new thread at interpreter shutdown)*

------
https://chatgpt.com/codex/tasks/task_e_685420d0f89483239bedc176a884265c