### PR TITLE
Fix examples/tests using v1 agent pattern

### DIFF
--- a/examples/agency_visualization_demo.py
+++ b/examples/agency_visualization_demo.py
@@ -14,17 +14,14 @@ from pathlib import Path
 # Add the src directory to the path so we can import agency_swarm
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from agency_swarm import Agency, Agent, BaseTool
+from agents import function_tool, RunContextWrapper
+from agency_swarm import Agency, Agent
 
 
-class ExampleTool(BaseTool):
-    """Example tool for demonstration"""
-
-    def __init__(self):
-        super().__init__(name="ExampleTool", description="An example tool for visualization demo")
-
-    def run(self, **kwargs):
-        return "Example tool executed"
+@function_tool()
+async def example_tool(wrapper: RunContextWrapper, **kwargs) -> str:
+    """Example tool for visualization demo"""
+    return "Example tool executed"
 
 
 def create_demo_agency():
@@ -42,21 +39,21 @@ def create_demo_agency():
         name="ProjectManager",
         description="Manages project timelines and coordinates between teams",
         instructions="You manage projects, timelines, and coordinate between different teams.",
-        tools=[ExampleTool()],
+        tools=[example_tool],
     )
 
     dev = Agent(
         name="Developer",
         description="Writes and maintains code",
         instructions="You write, test, and maintain code for various projects.",
-        tools=[ExampleTool()],
+        tools=[example_tool],
     )
 
     qa = Agent(
         name="QA",
         description="Tests software and ensures quality",
         instructions="You test software, find bugs, and ensure quality standards.",
-        tools=[ExampleTool()],
+        tools=[example_tool],
     )
 
     # Create agency with communication flows (v1.x pattern)

--- a/tests/integration/test_agent_to_agent_persistence.py
+++ b/tests/integration/test_agent_to_agent_persistence.py
@@ -14,27 +14,9 @@ from agents import ModelSettings
 from agency_swarm import Agency, Agent
 
 
-class CoordinatorAgent(Agent):
-    """Agent that coordinates tasks by delegating to workers."""
-
-    pass
-
-
-class WorkerAgent(Agent):
-    """Agent that performs work tasks."""
-
-    pass
-
-
-class MemoryAgent(Agent):
-    """Agent with memory storage capabilities for testing persistence."""
-
-    pass
-
-
 @pytest.fixture
 def coordinator_agent():
-    return CoordinatorAgent(
+    return Agent(
         name="Coordinator",
         instructions="You coordinate tasks. When asked to delegate, use send_message_to_Worker to ask the Worker agent to perform the task. Always include the full task details in your message.",
         model_settings=ModelSettings(temperature=0.0),
@@ -43,7 +25,7 @@ def coordinator_agent():
 
 @pytest.fixture
 def worker_agent():
-    return WorkerAgent(
+    return Agent(
         name="Worker",
         instructions="You perform tasks. When you receive a task, respond with 'TASK_COMPLETED: [task description]' to confirm completion.",
         model_settings=ModelSettings(temperature=0.0),
@@ -52,7 +34,7 @@ def worker_agent():
 
 @pytest.fixture
 def memory_agent():
-    return MemoryAgent(
+    return Agent(
         name="Memory",
         instructions="You have perfect memory. When told to remember something, confirm with 'REMEMBERED: [item]'. When asked to recall, respond with 'RECALLED: [item]'.",
         model_settings=ModelSettings(temperature=0.0),
@@ -195,19 +177,19 @@ class TestAgentToAgentPersistence:
         Verifies that different agent pairs maintain separate conversation histories.
         """
         # Create coordinator and two workers
-        coordinator = CoordinatorAgent(
+        coordinator = Agent(
             name="Coordinator",
             instructions="You coordinate tasks. Use send_message_to_Worker or send_message_to_Worker2 to delegate tasks.",
             model_settings=ModelSettings(temperature=0.0),
         )
 
-        worker1 = WorkerAgent(
+        worker1 = Agent(
             name="Worker",
             instructions="You are Worker. Respond with 'WORKER_COMPLETED: [task]' when given tasks.",
             model_settings=ModelSettings(temperature=0.0),
         )
 
-        worker2 = WorkerAgent(
+        worker2 = Agent(
             name="Worker2",
             instructions="You are Worker2. Respond with 'WORKER2_COMPLETED: [task]' when given tasks.",
             model_settings=ModelSettings(temperature=0.0),

--- a/tests/integration/test_communication.py
+++ b/tests/integration/test_communication.py
@@ -6,21 +6,9 @@ from agents import ModelSettings, RunResult
 from agency_swarm import Agency, Agent
 
 
-class PlannerAgent(Agent):
-    pass
-
-
-class WorkerAgent(Agent):
-    pass
-
-
-class ReporterAgent(Agent):
-    pass
-
-
 @pytest.fixture
 def planner_agent_instance():
-    return PlannerAgent(
+    return Agent(
         name="Planner",
         description="Plans the work.",
         instructions="You are a Planner. You will receive a task. Determine the steps. Delegate the execution step to the Worker agent using the send_message tool. Ensure your message to the Worker clearly includes the full and exact task description you received.",
@@ -30,7 +18,7 @@ def planner_agent_instance():
 
 @pytest.fixture
 def worker_agent_instance():
-    return WorkerAgent(
+    return Agent(
         name="Worker",
         description="Does the work.",
         instructions="You are a Worker. You will receive execution instructions from the Planner including a task description. Perform the task (simulate by creating a result string like 'Work done for: [task description]'). Send the result string to the Reporter agent using the send_message tool. Ensure your message clearly references the specific task description you were given by the Planner.",
@@ -40,7 +28,7 @@ def worker_agent_instance():
 
 @pytest.fixture
 def reporter_agent_instance():
-    return ReporterAgent(
+    return Agent(
         name="Reporter",
         description="Reports the results.",
         instructions="You are a Reporter. You will receive results from the Worker, which should reference a specific task description. Format this into a final report string. Ensure your final report clearly identifies the specific task description that was processed along with the results.",

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -86,13 +86,9 @@ def file_load_callback_error(thread_id: str, base_dir: Path) -> dict[str, Any] |
 
 
 # --- Test Agent ---
-class PersistenceTestAgent(Agent):
-    pass
-
-
 @pytest.fixture
 def persistence_agent():
-    return PersistenceTestAgent(
+    return Agent(
         name="PersistenceTester",
         instructions="Remember the secret code word I tell you. In the next turn, repeat the code word.",
     )
@@ -196,7 +192,7 @@ async def test_persistence_callbacks_called(temp_persistence_dir, persistence_ag
 
     # Turn 2 - new agency instance should load previous history
     print(f"\n--- Callback Test Turn 2 (Thread: {expected_thread_id}) --- MSG: {message2}")
-    persistence_agent2 = PersistenceTestAgent(
+    persistence_agent2 = Agent(
         name="PersistenceTester",
         instructions="Remember the secret code word I tell you. In the next turn, repeat the code word.",
     )
@@ -229,8 +225,8 @@ async def test_multi_thread_isolation_with_persistence(temp_persistence_dir, fil
     chat_id = "isolation_test_456"
 
     # Create two different agents
-    agent1 = PersistenceTestAgent(name="Agent1", instructions="You are Agent1.")
-    agent2 = PersistenceTestAgent(name="Agent2", instructions="You are Agent2.")
+    agent1 = Agent(name="Agent1", instructions="You are Agent1.")
+    agent2 = Agent(name="Agent2", instructions="You are Agent2.")
 
     # Get callback functions
     load_threads_for_chat, save_threads_for_chat = file_persistence_callbacks
@@ -296,8 +292,8 @@ async def test_persistence_load_all_threads(temp_persistence_dir, file_persisten
     chat_id = "multi_thread_test_789"
 
     # Create test agents
-    ceo = PersistenceTestAgent(name="CEO", instructions="You are the CEO.")
-    dev = PersistenceTestAgent(name="Developer", instructions="You are the Developer.")
+    ceo = Agent(name="CEO", instructions="You are the CEO.")
+    dev = Agent(name="Developer", instructions="You are the Developer.")
 
     # Get callback functions
     load_threads_for_chat, save_threads_for_chat = file_persistence_callbacks
@@ -373,7 +369,7 @@ async def test_persistence_error_handling(temp_persistence_dir, persistence_agen
     assert result is not None, "Should continue working despite load error"
 
     # Test save error handling - create separate agent instance
-    persistence_agent2 = PersistenceTestAgent(
+    persistence_agent2 = Agent(
         name="PersistenceTester",
         instructions="Remember the secret code word I tell you. In the next turn, repeat the code word.",
     )
@@ -411,7 +407,7 @@ async def test_no_persistence_no_callbacks(persistence_agent, temp_persistence_d
 
     # Agency Instance 2 - Turn 2 (No callbacks)
     print("\n--- No Persistence Test - Instance 2 - Turn 2 --- Creating Agency 2")
-    persistence_agent2 = PersistenceTestAgent(
+    persistence_agent2 = Agent(
         name="PersistenceTester",
         instructions="Remember the secret code word I tell you. In the next turn, repeat the code word.",
     )

--- a/tests/integration/test_thread_isolation_basic.py
+++ b/tests/integration/test_thread_isolation_basic.py
@@ -13,17 +13,9 @@ from agents import ModelSettings
 from agency_swarm import Agency, Agent
 
 
-class CEOAgent(Agent):
-    pass
-
-
-class DeveloperAgent(Agent):
-    pass
-
-
 @pytest.fixture
 def ceo_agent_instance():
-    return CEOAgent(
+    return Agent(
         name="CEO",
         description="Chief Executive Officer",
         instructions="You are the CEO. Remember information and delegate tasks.",
@@ -33,7 +25,7 @@ def ceo_agent_instance():
 
 @pytest.fixture
 def developer_agent_instance():
-    return DeveloperAgent(
+    return Agent(
         name="Developer",
         description="Software Developer",
         instructions="You are a Developer. Remember technical details.",

--- a/tests/integration/test_thread_isolation_persistence.py
+++ b/tests/integration/test_thread_isolation_persistence.py
@@ -16,17 +16,9 @@ from agents import ModelSettings
 from agency_swarm import Agency, Agent
 
 
-class CEOAgent(Agent):
-    pass
-
-
-class DeveloperAgent(Agent):
-    pass
-
-
 @pytest.fixture
 def ceo_agent_instance():
-    return CEOAgent(
+    return Agent(
         name="CEO",
         description="Chief Executive Officer",
         instructions="You are the CEO. Remember information and delegate tasks.",
@@ -36,7 +28,7 @@ def ceo_agent_instance():
 
 @pytest.fixture
 def developer_agent_instance():
-    return DeveloperAgent(
+    return Agent(
         name="Developer",
         description="Software Developer",
         instructions="You are a Developer. Remember technical details.",


### PR DESCRIPTION
## Summary
- remove deprecated BaseTool usage in visualization example
- refactor integration tests to use direct Agent instantiation

## Testing
- `make tests` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685dc785b91483238d24d378b00d43bd