### PR TITLE
Remove duplicate aggregator tests

### DIFF
--- a/tests/test_agency.py
+++ b/tests/test_agency.py
@@ -1,4 +1,0 @@
-# Import all agency tests from modular files
-from tests.test_agency_modules.test_agency_deprecated import *
-from tests.test_agency_modules.test_agency_initialization import *
-from tests.test_agency_modules.test_agency_responses import *

--- a/tests/test_agency_modules/test_agency_initialization.py
+++ b/tests/test_agency_modules/test_agency_initialization.py
@@ -63,12 +63,3 @@ def test_agency_initialization_persistence_hooks(mock_agent):
     # The callbacks are passed to ThreadManager and PersistenceHooks, not stored directly
 
 
-def test_agency_placeholder():
-    """Placeholder test to ensure Agency class can be imported and instantiated."""
-    # This test ensures the Agency class is properly defined and can be instantiated
-    # with minimal parameters. More comprehensive tests should be added as needed.
-    agent = MagicMock(spec=Agent)
-    agent.name = "TestAgent"
-    agency = Agency(agent)
-    assert agency is not None
-    assert "TestAgent" in agency.agents

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,6 +1,0 @@
-# Import all agent tests from modular files
-from tests.test_agent_modules.test_agent_core_responses import *
-from tests.test_agent_modules.test_agent_initialization import *
-from tests.test_agent_modules.test_agent_send_message import *
-from tests.test_agent_modules.test_agent_streaming import *
-from tests.test_agent_modules.test_agent_subagents import *


### PR DESCRIPTION
## Summary
- drop old aggregator modules that made pytest run tests twice
- delete placeholder Agency test

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_686dc7d0e7d083239d395c6115501703