### PR TITLE
Add observability tracing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 The **Agency Swarm Framework** is an advanced system for building multi-agent applications. It leverages and extends the foundational capabilities of the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python), providing specialized features for creating, orchestrating, and managing collaborative swarms of AI agents.
 
 By default, Agency Swarm is built on the **OpenAI Responses API** to handle complex, multi-turn interactions, with `examples/chat_completion_provider.py` being the only exception that uses the Chat Completions API.
+Observability tracking via Langfuse and AgentOps is demonstrated in `examples/observability_demo.py`.
 
 Agency Swarm enhances the underlying SDK by introducing:
 - True agent collaboration with flexible, user-defined communication flows (orchestrator-workers pattern with async execution support).

--- a/examples/observability_demo.py
+++ b/examples/observability_demo.py
@@ -1,0 +1,133 @@
+"""
+Observability demo showing Langfuse and AgentOps tracing.
+
+Run with: python examples/observability_demo.py
+"""
+
+import asyncio
+import logging
+import os
+import sys
+from typing import Any
+
+from dotenv import load_dotenv
+
+# Path setup for standalone examples
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from pydantic import BaseModel, Field
+from agents import ModelSettings, RunConfig, RunContextWrapper, function_tool, trace  # noqa: E402
+from langfuse import observe  # noqa: E402
+import agentops  # noqa: E402
+
+from agency_swarm import Agency, Agent  # noqa: E402
+
+load_dotenv()
+logging.basicConfig(level=logging.INFO)
+
+
+# ────────────────────────────────
+# Tool definition
+# ────────────────────────────────
+class MySDKToolArgs(BaseModel):
+    param1: str = Field(..., description="Test input for the tool. Does nothing")
+
+
+@function_tool
+async def test_tool(ctx: RunContextWrapper[Any], args: MySDKToolArgs) -> str:
+    """Return a predictable ID."""
+    return "Unique ID: 12332211"
+
+
+# ────────────────────────────────
+# Agency definition (agents + flows)
+# ────────────────────────────────
+
+def create_agency() -> Agency:
+    """Create agency with CEO, Developer, and Analyst."""
+    ceo = Agent(
+        name="CEO",
+        instructions="You are the CEO.",
+        description="Manages projects and coordinates between team members",
+        model="gpt-4.1",
+        tools=[test_tool],
+        model_settings=ModelSettings(temperature=0.3),
+    )
+
+    developer = Agent(
+        name="Developer",
+        instructions="You are the Developer.",
+        description="Implements technical solutions and writes code",
+        model="gpt-4.1",
+        tools=[test_tool],
+        model_settings=ModelSettings(temperature=0.3),
+    )
+
+    analyst = Agent(
+        name="Data Analyst",
+        instructions="You are the Data Analyst.",
+        description="Analyzes data and provides insights",
+        model="gpt-4.1",
+        tools=[test_tool],
+        model_settings=ModelSettings(temperature=0.3),
+    )
+
+    return Agency(
+        ceo,
+        developer,
+        analyst,
+        communication_flows=[
+            (ceo, developer),
+            (ceo, analyst),
+            (developer, analyst),
+        ],
+        temperature=0.01,
+    )
+
+
+# ────────────────────────────────
+# Tracing wrappers
+# ────────────────────────────────
+async def openai_tracing(input_message: str) -> str:
+    agency_instance = create_agency()
+    with trace("Openai tracing"):
+        response = await agency_instance.get_response(message=input_message)
+    return response.final_output
+
+
+@observe()
+async def langfuse_tracing(input_message: str) -> str:
+    agency_instance = create_agency()
+
+    @observe()
+    async def get_response_wrapper(message: str):
+        return await agency_instance.get_response(
+            message=message,
+            run_config=RunConfig(tracing_disabled=True),
+        )
+
+    response = await get_response_wrapper(input_message)
+    return response.final_output
+
+
+async def agentops_tracing(input_message: str) -> str:
+    agentops.init(auto_start_session=True, trace_name="Agentops tracing", tags=["openai", "agentops-example"])
+    tracer = agentops.start_trace(trace_name="Agentops tracing", tags=["openai", "agentops-example"])
+
+    agency_instance = create_agency()
+    response = await agency_instance.get_response(message=input_message)
+    agentops.end_trace(tracer, end_state="Success")
+    return response.final_output
+
+
+# ────────────────────────────────
+# Entry point
+# ────────────────────────────────
+if __name__ == "__main__":
+    if not os.getenv("OPENAI_API_KEY"):
+        print("❌ Set OPENAI_API_KEY environment variable")
+        sys.exit(1)
+
+    msg = "Hi, use the test tool please."
+    print(f"Agentops tracing: {asyncio.run(agentops_tracing(msg))}\n")
+


### PR DESCRIPTION
## Summary
- add `observability_demo.py` demonstrating Langfuse and AgentOps tracing with three agents
- mention new example in README

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_686e688514fc8323b96059c5d136b023