### PR TITLE
Add synchronous wrapper for agency responses

### DIFF
--- a/src/agency_swarm/agency.py
+++ b/src/agency_swarm/agency.py
@@ -562,6 +562,34 @@ class Agency:
         ):
             yield event
 
+    def get_response_sync(
+        self,
+        message: str | list[dict[str, Any]],
+        recipient_agent: str | Agent | None = None,
+        context_override: dict[str, Any] | None = None,
+        hooks_override: RunHooks | None = None,
+        run_config: RunConfig | None = None,
+        message_files: list[str] | None = None,
+        file_ids: list[str] | None = None,
+        additional_instructions: str | None = None,
+        **kwargs: Any,
+    ) -> RunResult:
+        """Synchronous wrapper around :meth:`get_response`."""
+
+        return asyncio.run(
+            self.get_response(
+                message=message,
+                recipient_agent=recipient_agent,
+                context_override=context_override,
+                hooks_override=hooks_override,
+                run_config=run_config,
+                message_files=message_files,
+                file_ids=file_ids,
+                additional_instructions=additional_instructions,
+                **kwargs,
+            )
+        )
+
     def _resolve_agent(self, agent_ref: str | Agent) -> Agent:
         """Helper to get an agent instance from a name or instance."""
         if isinstance(agent_ref, Agent):

--- a/tests/test_agency_modules/test_agency_responses.py
+++ b/tests/test_agency_modules/test_agency_responses.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from agents import RunHooks
@@ -159,3 +159,17 @@ async def test_agent_communication_context_hooks_propagation(mock_agent, mock_ag
     call_kwargs = mock_agent.get_response.call_args[1]
     assert "context_override" in call_kwargs
     assert "hooks_override" in call_kwargs
+
+
+def test_get_response_sync_calls_async_method(mock_agent):
+    """Ensure get_response_sync calls the async get_response."""
+    agency = Agency(mock_agent)
+    mock_result = MagicMock(final_output="Sync Response")
+
+    with patch.object(agency, "get_response", new_callable=AsyncMock) as mock_async:
+        mock_async.return_value = mock_result
+
+        result = agency.get_response_sync("Hello")
+
+    assert result.final_output == "Sync Response"
+    mock_async.assert_called_once()


### PR DESCRIPTION
## Summary
- expose `Agency.get_response_sync` for convenient sync entry
- unit test for new wrapper

## Testing
- `make tests` *(fails: test_file_attachment_citation_extraction, test_agency_get_completion_calls_get_response)*
- `python examples/streaming.py`
- `python examples/file_search.py`
- `python examples/custom_send_message_with_context.py`


------
https://chatgpt.com/codex/tasks/task_e_68822d70c89083239645099613b792d8