### PR TITLE
Fix migration docs typos

### DIFF
--- a/docs/additional-features/agency-context.mdx
+++ b/docs/additional-features/agency-context.mdx
@@ -100,7 +100,7 @@ You can use agency context in your function tools and access it in agents. Here'
             # Fetch data based on the question
             context = query_database_api(self.question)
             # Store the context in agency context
-            context = self.shared_state.set('database_context', context)
+            self.shared_state.set('database_context', context)
             return "Context has been retrieved and stored successfully."
     ```
 

--- a/docs/additional-features/azure-openai.mdx
+++ b/docs/additional-features/azure-openai.mdx
@@ -34,7 +34,7 @@ from openai import AsyncOpenAI
 
 azure_agent = AsyncOpenAI(
     api_key=os.getenv("AZURE_OPENAI_KEY"),
-    default_query={"api-version": "preview"}, 
+    default_query={"api-version": "preview"},
     base_url=os.getenv("AZURE_ENDPOINT") + "/openai/v1/",
 )
 ```
@@ -57,7 +57,7 @@ azure_agent = Agent(
 )
 ```
 <Note>
-Model deployment name might be different from the stadard OpenAI model names. It is set by you when you deploy a model to Azure.
+Model deployment name might be different from the standard OpenAI model names. It is set by you when you deploy a model to Azure.
 </Note>
 
 </Step>
@@ -117,7 +117,7 @@ ceo = Agent(
 )
 ```
 <Note>
-Model deployment name might be different from the stadard OpenAI model names. It is set by you when you deploy a model to Azure.
+Model deployment name might be different from the standard OpenAI model names. It is set by you when you deploy a model to Azure.
 </Note>
 
 </Step>

--- a/docs/additional-features/open-source-models.mdx
+++ b/docs/additional-features/open-source-models.mdx
@@ -50,7 +50,7 @@ Add your API keys to your environment variables:
 
 ```bash
 export GEMINI_API_KEY="your-gemini-api-key"
-export ANTHROPIC_API_KEY="your-anthropic-api-key" 
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
 export GROQ_API_KEY="your-groq-api-key"
 ```
 </Step>
@@ -83,7 +83,7 @@ gemini_agent = Agent(
     name="GeminiAgent",
     instructions="You are a helpful assistant",
     model=OpenAIChatCompletionsModel(
-        model="gemini/gemini-2.0-flash", 
+        model="gemini/gemini-2.0-flash",
         openai_client=custom_client
     )
 )
@@ -300,7 +300,7 @@ agency.get_completion("I am the CEO")
 Be aware of the limitations when using open-source models.
 </Warning>
 
-- **Function calling may not supported by some open-source models**: This limitation prevents the agent from communicating with other agents in the agency. Therefore, it must be positioned at the end of the agency chart and cannot utilize any tools.
+- **Function calling may not be supported by some open-source models**: This limitation prevents the agent from communicating with other agents in the agency. Therefore, it must be positioned at the end of the agency chart and cannot utilize any tools.
 - **RAG is typically limited**: Most open-source implementations have restricted Retrieval-Augmented Generation capabilities. It is recommended to develop a custom tool with your own vector database.
 
 ## Future Plans


### PR DESCRIPTION
## Summary
- correct shared state example in agency context guide
- fix typos in Azure OpenAI and open source model docs

## Testing
- `pre-commit run --files docs/additional-features/agency-context.mdx docs/additional-features/azure-openai.mdx docs/additional-features/open-source-models.mdx`
- `pytest -v` *(fails: 5 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688186d3468083238ec18c581dfed51b