### PR TITLE
Fix run_async_sync handling in running loops

### DIFF
--- a/agency_swarm/util/helpers/sync_async.py
+++ b/agency_swarm/util/helpers/sync_async.py
@@ -1,20 +1,14 @@
 import asyncio
 
+
 def run_async_sync(async_fn, *args, **kwargs):
-    """
-    Runs an async function synchronously, handling event loop logic.
-    This is useful for wrapping async code in a sync interface.
-    """
+    """Run an async function synchronously."""
     try:
         loop = asyncio.get_running_loop()
-        if loop.is_running():
-            # If already in an event loop, create a new task and run it
-            # This will block the current thread until the task is done
-            # but is not ideal for nested event loops. For most agent use cases,
-            # we assume sync context, so fallback to asyncio.run otherwise.
-            return asyncio.run(async_fn(*args, **kwargs))
-        else:
-            return asyncio.run(async_fn(*args, **kwargs))
     except RuntimeError:
-        # No event loop, safe to use asyncio.run
-        return asyncio.run(async_fn(*args, **kwargs)) 
+        loop = None
+
+    if loop and loop.is_running():
+        raise RuntimeError("run_async_sync cannot be called from a running event loop")
+
+    return asyncio.run(async_fn(*args, **kwargs))

--- a/tests/test_sync_async.py
+++ b/tests/test_sync_async.py
@@ -1,0 +1,20 @@
+import asyncio
+
+import pytest
+
+from agency_swarm.util.helpers import run_async_sync
+
+
+async def add(a, b):
+    await asyncio.sleep(0)
+    return a + b
+
+
+def test_run_async_sync_basic():
+    assert run_async_sync(add, 1, 2) == 3
+
+
+@pytest.mark.asyncio
+async def test_run_async_sync_in_running_loop():
+    with pytest.raises(RuntimeError):
+        run_async_sync(add, 1, 2)


### PR DESCRIPTION
## Summary
- improve run_async_sync so it raises an explicit error if called from an active event loop
- add regression tests for run_async_sync

## Testing
- `pytest -v tests/test_sync_async.py`
- `pytest -v` *(fails: FileNotFoundError and KeyboardInterrupt for OpenAI tests)*
- `pre-commit run --files agency_swarm/util/helpers/sync_async.py tests/test_sync_async.py`

------
https://chatgpt.com/codex/tasks/task_e_68818527cb5c8323a3131e9fecc0e0fa