### PR TITLE
Add synchronous agency response method

### DIFF
--- a/src/agency_swarm/agency.py
+++ b/src/agency_swarm/agency.py
@@ -486,6 +486,34 @@ class Agency:
             **kwargs,
         )
 
+    def get_response_sync(
+        self,
+        message: str | list[dict[str, Any]],
+        recipient_agent: str | Agent | None = None,
+        context_override: dict[str, Any] | None = None,
+        hooks_override: RunHooks | None = None,
+        run_config: RunConfig | None = None,
+        message_files: list[str] | None = None,
+        file_ids: list[str] | None = None,
+        additional_instructions: str | None = None,
+        **kwargs: Any,
+    ) -> RunResult:
+        """Synchronous wrapper around :meth:`get_response`."""
+
+        return asyncio.run(
+            self.get_response(
+                message=message,
+                recipient_agent=recipient_agent,
+                context_override=context_override,
+                hooks_override=hooks_override,
+                run_config=run_config,
+                message_files=message_files,
+                file_ids=file_ids,
+                additional_instructions=additional_instructions,
+                **kwargs,
+            )
+        )
+
     async def get_response_stream(
         self,
         message: str | list[dict[str, Any]],

--- a/tests/test_agency_modules/test_agency_deprecated.py
+++ b/tests/test_agency_modules/test_agency_deprecated.py
@@ -33,3 +33,15 @@ def test_agency_get_completion_calls_get_response(mock_agent):
     assert result == "Test response"
     # Should call get_response on the first agent in the chart
     mock_agent.get_response.assert_called_once()
+
+
+def test_agency_get_response_sync_calls_get_response(mock_agent):
+    """Test that get_response_sync calls the async get_response method."""
+    agency = Agency(mock_agent)
+
+    mock_agent.get_response.return_value = MagicMock(final_output="Sync response")
+
+    result = agency.get_response_sync("Test message")
+
+    assert result.final_output == "Sync response"
+    mock_agent.get_response.assert_called_once()


### PR DESCRIPTION
## Summary
- implement `get_response_sync` to call the async `get_response`
- add a unit test verifying the wrapper

## Testing
- `make ci` *(fails: E501 line too long)*
- `python examples/agency_terminal_demo.py` *(fails: ModuleNotFoundError: No module named 'agents')*
- `python examples/multi_agent_workflow.py` *(fails: ModuleNotFoundError: No module named 'agents')*
- `python -m pytest tests/integration/ -v` *(fails: ModuleNotFoundError: No module named 'agency_swarm')*

------
https://chatgpt.com/codex/tasks/task_e_68881653c0d48323bd0d498c800e7e3b