### PR TITLE
Add web search metadata test

### DIFF
--- a/tests/integration/test_responses_api_tools.py
+++ b/tests/integration/test_responses_api_tools.py
@@ -411,5 +411,3 @@ Product Sales:
         )
 
         logger.info("✅ Hosted tool output preservation test completed successfully")
-
-

--- a/tests/integration/test_responses_api_tools.py
+++ b/tests/integration/test_responses_api_tools.py
@@ -11,8 +11,14 @@ from agents import (
     Runner,
     function_tool,
 )
+from agents.items import MessageOutputItem, ToolCallItem
 from agents.models.openai_responses import OpenAIResponsesModel
 from openai import AsyncOpenAI
+from openai.types.responses import (
+    ResponseFunctionWebSearch,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
 from pydantic import BaseModel
 
 from agency_swarm import Agent as AgencySwarmAgent
@@ -404,4 +410,7 @@ Product Sales:
             f"Only found {data_access_score}/4 specific data points in response: {response_text}"
         )
 
-        logger.info("✅ Hosted tool output preservation test completed successfully")
+
+logger.info("✅ Hosted tool output preservation test completed successfully")
+
+

--- a/tests/integration/test_responses_api_tools.py
+++ b/tests/integration/test_responses_api_tools.py
@@ -411,6 +411,6 @@ Product Sales:
         )
 
 
-logger.info("✅ Hosted tool output preservation test completed successfully")
+    logger.info("✅ Hosted tool output preservation test completed successfully")
 
 

--- a/tests/integration/test_responses_api_tools.py
+++ b/tests/integration/test_responses_api_tools.py
@@ -410,7 +410,6 @@ Product Sales:
             f"Only found {data_access_score}/4 specific data points in response: {response_text}"
         )
 
-
-    logger.info("✅ Hosted tool output preservation test completed successfully")
+        logger.info("✅ Hosted tool output preservation test completed successfully")
 
 

--- a/tests/test_agent_modules/test_hosted_tool_results.py
+++ b/tests/test_agent_modules/test_hosted_tool_results.py
@@ -1,0 +1,51 @@
+import pytest
+from agents.items import MessageOutputItem, ToolCallItem
+from openai.types.responses.response_function_web_search import ActionSearch, ResponseFunctionWebSearch
+from openai.types.responses.response_output_message import ResponseOutputMessage, ResponseOutputText
+
+from agency_swarm.agent.execution import Execution
+from agency_swarm.agent_core import Agent
+
+
+@pytest.mark.asyncio
+async def test_web_search_results_have_metadata():
+    """Verify web search results are returned as user messages with metadata."""
+    agent = Agent(name="MetaAgent", instructions="Test")
+    exec_handler = Execution(agent)
+
+    web_call = ResponseFunctionWebSearch(
+        id="1",
+        action=ActionSearch(query="hello", type="search"),
+        status="completed",
+        type="web_search_call",
+    )
+
+    assistant_msg = ResponseOutputMessage(
+        id="m1",
+        content=[ResponseOutputText(annotations=[], text="result", type="output_text")],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+
+    run_items = [
+        ToolCallItem(agent, web_call),
+        MessageOutputItem(agent, assistant_msg),
+    ]
+
+    results = exec_handler._extract_hosted_tool_results(run_items)
+
+    assert results, "Expected hosted tool result"
+    result = results[0]
+    assert result.get("agent") == agent.name
+    assert result.get("callerAgent") is None
+    assert "WEB_SEARCH_RESULTS" in result.get("content", "")
+
+
+def test_extract_no_results_returns_empty():
+    """Ensure empty list is returned when no hosted tool calls present."""
+    agent = Agent(name="EmptyAgent", instructions="Test")
+    exec_handler = Execution(agent)
+
+    results = exec_handler._extract_hosted_tool_results([])
+    assert results == []


### PR DESCRIPTION
## Summary
- rename tool cycle integration tests for clarity
- add unit tests for hosted tool result metadata

## Testing
- `make ci` *(fails: lint errors)*
- `uv run python examples/agency_terminal_demo.py` *(interrupted: awaiting input)*
- `uv run python examples/multi_agent_workflow.py`
- `uv run pytest tests/integration/ -v` *(all tests passed, interrupted after completion)*

------
https://chatgpt.com/codex/tasks/task_e_688cd953414883238b1b33198ed4e183