### PR TITLE
refactor: type hint shared state accessor

### DIFF
--- a/src/agency_swarm/tools/BaseTool.py
+++ b/src/agency_swarm/tools/BaseTool.py
@@ -10,6 +10,8 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
+from ..context import MasterContext
+
 from docstring_parser import parse
 from openai.types.beta.threads.runs.tool_call import ToolCall
 from pydantic import BaseModel
@@ -93,14 +95,14 @@ class BaseTool(BaseModel, ABC):
         return schema
 
     @property
-    def context(self):
+    def context(self) -> MasterContext | None:
         """Get the MasterContext if available, providing clean access to shared state."""
         if self._context is not None:
             return self._context.context
         return None
 
     @property
-    def _shared_state(self):
+    def _shared_state(self) -> MasterContext | None:
         """
         Backwards compatibility property that provides direct access to the context.
 
@@ -112,7 +114,7 @@ class BaseTool(BaseModel, ABC):
             "_shared_state is deprecated and will be removed in future versions. "
             "Use 'self.context' instead.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         return self.context
 

--- a/tests/test_agent_modules/test_tool_system.py
+++ b/tests/test_agent_modules/test_tool_system.py
@@ -350,6 +350,18 @@ def test_tools_folder_nonexistent_path():
     assert agent.tools == []
 
 
+@pytest.mark.asyncio
+async def test_shared_state_property(mock_run_context_wrapper):
+    class TestTool(BaseTool):
+        def run(self):
+            return "ok"
+
+    tool = TestTool()
+    tool._context = mock_run_context_wrapper
+    with pytest.deprecated_call():
+        assert tool._shared_state is mock_run_context_wrapper.context
+
+
 # TODO: Add tests for response validation aspects
 # TODO: Add tests for context/hooks propagation (more complex, might need integration tests)
 # TODO: Add parameterized tests for various message inputs (empty, long, special chars)


### PR DESCRIPTION
## Summary
- add MasterContext type hints for `BaseTool.context` and deprecated `_shared_state`
- test deprecated `_shared_state` returns underlying context

## Testing
- `make ci` *(fails: lint errors)*
- `python examples/agency_terminal_demo.py` *(fails: ModuleNotFoundError: No module named 'agents')*
- `python examples/multi_agent_workflow.py` *(fails: ModuleNotFoundError: No module named 'agents')*
- `python -m pytest tests/integration/ -v` *(fails: async def functions are not natively supported)*
- `uv run pytest tests/integration/test_file_handling.py -v --tb=short`


------
https://chatgpt.com/codex/tasks/task_e_6890cbb122408323b78bf295b9410f20