### PR TITLE
fix: resolve lint warnings in UI converter tests

### DIFF
--- a/tests/test_agent_modules/test_ui_converters.py
+++ b/tests/test_agent_modules/test_ui_converters.py
@@ -446,7 +446,7 @@ class TestConsoleEventAdapter:
         event.data.type = "response.output_text.delta"
         event.data.delta = "Hello"
 
-        with patch.object(adapter, "_update_console") as mock_update:
+        with patch.object(adapter, "_update_console"):
             adapter.openai_to_message_output(event, "TestAgent")
             # This specific path may not call _update_console directly
             # but should not raise errors
@@ -506,7 +506,17 @@ class TestConsoleEventAdapter:
             # Raw response error scenarios
             ("missing_message_id", {"type": "response.output_item.added", "item_type": "message", "id": None}, None),
             # Skip problematic validation error test
-            # ("missing_tool_call_id", {"type": "response.output_item.added", "item_type": "function_call", "call_id": None, "name": "test", "arguments": "{}"}, None),
+            # (
+            #     "missing_tool_call_id",
+            #     {
+            #         "type": "response.output_item.added",
+            #         "item_type": "function_call",
+            #         "call_id": None,
+            #         "name": "test",
+            #         "arguments": "{}",
+            #     },
+            #     None,
+            # ),
             ("missing_text_delta_id", {"type": "response.output_text.delta", "item_id": None}, None),
             # Run item stream error scenarios
             ("missing_item", {"name": "message_output_created", "item": None}, None),


### PR DESCRIPTION
## Summary
- remove unused mock variable in console event adapter test
- wrap commented-out test case for readability

## Testing
- `make lint` *(fails: E722 and E731 remain)*
- `make ci` *(fails: same lint errors as above)*
- `python examples/agency_terminal_demo.py` *(fails: ModuleNotFoundError: No module named 'agents')*
- `python examples/multi_agent_workflow.py` *(fails: ModuleNotFoundError: No module named 'agents')*
- `uv run pytest tests/integration/ -v`

------
https://chatgpt.com/codex/tasks/task_e_6890cbb122408323b78bf295b9410f20