### PR TITLE
Fix linter issues in tools and tests

### DIFF
--- a/src/agency_swarm/tools/BaseTool.py
+++ b/src/agency_swarm/tools/BaseTool.py
@@ -10,11 +10,11 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
-from ..context import MasterContext
-
 from docstring_parser import parse
 from openai.types.beta.threads.runs.tool_call import ToolCall
 from pydantic import BaseModel
+
+from ..context import MasterContext
 
 
 class classproperty:
@@ -30,7 +30,6 @@ class BaseTool(BaseModel, ABC):
     _event_handler: Any = None
     _tool_call: ToolCall = None
     _context: Any = None  # Will hold RunContextWrapper when available
-    openai_schema: ClassVar[dict[str, Any]]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/src/agency_swarm/tools/__init__.py
+++ b/src/agency_swarm/tools/__init__.py
@@ -1,5 +1,5 @@
 from .BaseTool import BaseTool
-from .ToolFactory import ToolFactory
 from .send_message import SendMessage, SendMessageHandoff
+from .ToolFactory import ToolFactory
 
 __all__ = ["BaseTool", "ToolFactory", "SendMessage", "SendMessageHandoff"]

--- a/tests/integration/test_agent_handoffs.py
+++ b/tests/integration/test_agent_handoffs.py
@@ -94,7 +94,6 @@ class TestHandoffsWithCommunicationFlows:
 
         # Get tool names for each agent
         agent_a_tools = [tool.name if hasattr(tool, "name") else str(tool) for tool in agent_a.tools]
-        agent_b_tools = [tool.name if hasattr(tool, "name") else str(tool) for tool in agent_b.tools]
         agent_c_tools = [tool.name if hasattr(tool, "name") else str(tool) for tool in agent_c.tools]
 
         # AgentA should have a unified send_message tool
@@ -122,7 +121,6 @@ class TestHandoffsWithCommunicationFlows:
     def test_sendmessage_tool_recipients(self, mixed_communication_agency):
         """Test that SendMessage tool has the correct recipients."""
         agent_a = mixed_communication_agency.agents["AgentA"]
-        agent_b = mixed_communication_agency.agents["AgentB"]
 
         # Find the unified send_message tool
         sendmessage_tools = [tool for tool in agent_a.tools if hasattr(tool, "name") and tool.name == "send_message"]


### PR DESCRIPTION
## Summary
- sort imports in tools modules
- remove unused variables in handoff tests
- drop redundant `openai_schema` annotation

## Testing
- `make ci` *(fails: Need type annotation for "graph" (var-annotated))*
- `uv run python examples/multi_agent_workflow.py` *(fails: AttributeError: module 'tensorflow' has no attribute 'contrib')*
- `uv run python -m pytest tests/integration/ -v` *(fails: AttributeError: module 'tensorflow' has no attribute 'contrib')*

------
https://chatgpt.com/codex/tasks/task_e_6896478e89bc8323b5a5a26b21743ca8