### PR TITLE
Ensure uploaded files are processed before search

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -46,7 +46,6 @@ def make_response_endpoint(request_model, agency_factory: Callable[..., Agency],
             try:
                 file_ids_map = await upload_from_urls(request.file_urls)
                 combined_file_ids = (combined_file_ids or []) + list(file_ids_map.values())
-                await asyncio.sleep(6)  # Wait until files are ready for retrieval
             except Exception as e:
                 return {"error": f"Error downloading file from provided urls: {e}"}
 
@@ -91,7 +90,6 @@ def make_stream_endpoint(request_model, agency_factory: Callable[..., Agency], v
             try:
                 file_ids_map = await upload_from_urls(request.file_urls)
                 combined_file_ids = (combined_file_ids or []) + list(file_ids_map.values())
-                await asyncio.sleep(6)  # Wait until files are ready for retrieval
             except Exception as e:
                 error_msg = str(e)
 


### PR DESCRIPTION
## Summary
- Wait for OpenAI files to finish processing before returning IDs
- Remove fixed sleep and rely on processed file IDs in FastAPI endpoints
