### PR TITLE
Remove pointless UI converter tests and ensure package install

### DIFF
--- a/run/setup.sh
+++ b/run/setup.sh
@@ -23,6 +23,9 @@ fi
 export UV_FROZEN=1
 make sync
 
+# Install package in editable mode to ensure dependencies like openai-agents are available
+pip install -e .
+
 # Create .env if missing
 if [ ! -f ".env" ]; then
     cat > .env << EOF

--- a/tests/test_agent_modules/test_ui_converters.py
+++ b/tests/test_agent_modules/test_ui_converters.py
@@ -99,16 +99,6 @@ class TestSerialize:
 
 
 class TestAguiAdapter:
-    def test_raw_response_event(self):
-        event = MagicMock()
-        event.type = "raw_response_event"
-        event.data = MagicMock()
-        event.data.type = "response.content.delta"
-
-        result = AguiAdapter.openai_to_agui_events(event, run_id="test")
-        # Test that it handles the event without error
-        assert result is not None or result is None  # Either is fine
-
     def test_exception_handling(self):
         event = MagicMock()
         event.type = "raw_response_event"
@@ -176,28 +166,6 @@ class TestAguiAdapter:
         call_id, tool_name, _ = AguiAdapter._tool_meta(item)
         assert call_id == expected_call_id
         assert tool_name == expected_name
-
-    def test_handle_raw_response_basic(self):
-        """Test the _handle_raw_response method with basic content."""
-        data = MagicMock()
-        data.type = "response.content.delta"
-        data.delta = [MagicMock()]
-        data.delta[0].type = "text"
-        data.delta[0].text = "test content"
-
-        # This should not raise an error
-        result = AguiAdapter._handle_raw_response(data, {})
-        assert result is not None or result is None  # Either is fine
-
-    def test_handle_run_item_stream_basic(self):
-        """Test the _handle_run_item_stream method with basic event."""
-        event = MagicMock()
-        event.item = MagicMock()
-        event.item.type = "message_item"
-
-        # This should not raise an error
-        result = AguiAdapter._handle_run_item_stream(event)
-        assert result is not None or result is None  # Either is fine
 
     @pytest.mark.parametrize(
         "event_type,item_config,expected_type,should_track",


### PR DESCRIPTION
## Summary
- Drop placeholder AguiAdapter tests that asserted tautologies
- Install package in setup to expose openai-agents and other deps

## Testing
- `make ci` *(fails: mypy type errors in agent_core and other modules)*
- `python examples/agency_terminal_demo.py` *(fails: file not found)*
- `python examples/multi_agent_workflow.py` *(fails: ModuleNotFoundError: agents)*
- `python -m pytest tests/integration/ -v` *(fails: async def functions are not natively supported; 46 failed, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5e497bc832399d87351c9aa5934