### PR TITLE
Remove redundant visualization test and clarify console output handling

### DIFF
--- a/tests/test_agency_modules/test_ui.py
+++ b/tests/test_agency_modules/test_ui.py
@@ -367,13 +367,6 @@ class TestAgencyVisualizationIntegration:
             assert "x" in node["position"]
             assert "y" in node["position"]
 
-    def test_visualization_module_import(self):
-        """Test that visualization modules can be imported."""
-        from agency_swarm.ui import HTMLVisualizationGenerator, LayoutAlgorithms
-
-        assert HTMLVisualizationGenerator is not None
-        assert LayoutAlgorithms is not None
-
     def test_layout_algorithms_manager_vs_leaf_positioning(self):
         """Test that manager agents and leaf agents position tools differently."""
         # Create a more complex structure with manager and leaf agents

--- a/tests/test_agent_modules/test_ui_converters.py
+++ b/tests/test_agent_modules/test_ui_converters.py
@@ -422,10 +422,10 @@ class TestConsoleEventAdapter:
         event.data.type = "response.output_text.delta"
         event.data.delta = "Hello"
 
-        with patch.object(adapter, "_update_console"):
+        with patch.object(adapter, "_update_console") as mock_update:
             adapter.openai_to_message_output(event, "TestAgent")
-            # This specific path may not call _update_console directly
-            # but should not raise errors
+            # This specific path should not trigger console updates
+            mock_update.assert_not_called()
 
     def test_openai_to_message_output_send_message_detection(self, adapter):
         """Test openai_to_message_output detects send_message pattern."""


### PR DESCRIPTION
## Summary
- drop pointless `test_visualization_module_import` which only checked module imports
- verify console event adapter doesn't trigger console updates on delta events

## Testing
- `make format`
- `make lint`
- `make mypy` *(fails: missing type annotations in layout_algorithms.py)*
- `python examples/multi_agent_workflow.py`
- `python examples/agency_terminal_demo.py` *(fails: file not found)*
- `uv run pytest tests/integration/ -v` *(interrupted: context errors during teardown)*
- `make ci` *(fails: mypy type annotation errors)*

------
https://chatgpt.com/codex/tasks/task_e_689909f82a9c83238d00463028183dde