### PR TITLE
Streaming: simplify get_response_stream by removing internal queue/wo…

### DIFF
--- a/tests/integration/test_fastapi_file_processing.py
+++ b/tests/integration/test_fastapi_file_processing.py
@@ -6,7 +6,6 @@ process various file types through HTTP requests, and return appropriate respons
 containing the expected file content.
 """
 
-import asyncio
 import subprocess
 import sys
 import time


### PR DESCRIPTION
…rker; manage MCP lifecycle with AsyncExitStack; cancel RunResultStreaming on exit. Docs: forbid global executables; enforce uv run for examples/tests. Lint: remove unused asyncio import in FastAPI test.