### PR TITLE
Fix custom SendMessage tool constructor in example

### DIFF
--- a/examples/custom_send_message_with_context.py
+++ b/examples/custom_send_message_with_context.py
@@ -38,8 +38,8 @@ logging.getLogger("agency_swarm").setLevel(
 class SendMessageWithContext(SendMessage):
     """SendMessage with key moments and decisions tracking."""
 
-    def __init__(self, sender_agent, recipient_agent, tool_name):
-        super().__init__(sender_agent, recipient_agent, tool_name)
+    def __init__(self, sender_agent: Agent, recipients: dict[str, Agent] | None = None) -> None:
+        super().__init__(sender_agent, recipients)
 
         # Add 2 additional fields to the params schema with rich descriptions
         self.params_json_schema["properties"]["key_moments"] = {


### PR DESCRIPTION
## Summary
- fix SendMessageWithContext class to accept recipient mapping like base SendMessage
- add type hints to custom SendMessageWithContext

## Testing
- `make format`
- `make ci` *(fails: Item "None" of "AgentFileManager | None" has no attribute "read_instructions" etc.)*
- `python examples/multi_agent_workflow.py`
- `python -m pytest tests/integration/ -v` *(fails: async def functions are not natively supported)*
- `python examples/custom_send_message_with_context.py`


------
https://chatgpt.com/codex/tasks/task_e_689a2f022bb08323a28375118952edcf