### PR TITLE
chore: clean up basetool integration test

### DIFF
--- a/tests/integration/test_basetool_context_integration.py
+++ b/tests/integration/test_basetool_context_integration.py
@@ -6,33 +6,6 @@ from pydantic import Field
 from agency_swarm import Agency, Agent, BaseTool
 
 
-class StoreDataTool(BaseTool):
-    """Store data in agency context using BaseTool."""
-
-    key: str = Field(..., description="Key to store data under")
-    value: str = Field(..., description="Value to store")
-
-    def run(self):
-        if self.context is not None:
-            self.context.set(self.key, self.value)
-            return f"Stored {self.key}={self.value}"
-        else:
-            return "Error: No context available"
-
-
-class RetrieveDataTool(BaseTool):
-    """Retrieve data from agency context using BaseTool."""
-
-    key: str = Field(..., description="Key to retrieve data for")
-
-    def run(self):
-        if self.context is not None:
-            value = self.context.get(self.key, "not_found")
-            return f"Retrieved {self.key}={value}"
-        else:
-            return "Error: No context available"
-
-
 @pytest.mark.asyncio
 async def test_basetool_context_integration():
     """Test that BaseTools can access agency context."""


### PR DESCRIPTION
## Summary
- remove unused BaseTool implementations from `test_basetool_context_integration`

## Testing
- `make ci` *(fails: Module has no attribute "adapt_base_tool")*
- `uv run python examples/agency_terminal_demo.py` *(fails: file not found)*
- `uv run python examples/multi_agent_workflow.py`
- `uv run pytest tests/integration/ -v` *(fails: APIError during streaming response)*

------
https://chatgpt.com/codex/tasks/task_e_689c6c8a98588323864b68b811024c14