### PR TITLE
Remove non-functional layout test

### DIFF
--- a/tests/test_agency_modules/test_ui.py
+++ b/tests/test_agency_modules/test_ui.py
@@ -143,18 +143,6 @@ class TestLayoutAlgorithms:
             assert "x" in node["position"]
             assert "y" in node["position"]
 
-    def test_apply_layout_different_dimensions(self, sample_agency_data):
-        """Test apply_layout with different width and height."""
-        result1 = LayoutAlgorithms.apply_layout(sample_agency_data, width=400, height=300)
-        result2 = LayoutAlgorithms.apply_layout(sample_agency_data, width=1200, height=900)
-
-        # Positions should be different for different canvas sizes
-        node1_pos1 = next(n["position"] for n in result1["nodes"] if n["id"] == "CEO")
-        node1_pos2 = next(n["position"] for n in result2["nodes"] if n["id"] == "CEO")
-
-        # At least one coordinate should be different (positions adapt to canvas size)
-        assert node1_pos1 != node1_pos2 or True  # Layout may be the same but that's OK
-
 
 class TestHTMLVisualizationGenerator:
     """Test the HTML visualization generator."""


### PR DESCRIPTION
## Summary
- Remove meaningless layout comparison test in UI suite

## Testing
- `make ci` *(fails: multiple mypy errors in src/ files)*
- `uv run python examples/interactive/terminal_demo.py`
- `uv run python examples/multi_agent_workflow.py`
- `uv run pytest tests/integration/ -v` *(fails: interrupted during test_communication)*

------
https://chatgpt.com/codex/tasks/task_e_689d538bedc08323b179cbbc8d046cb1