### PR TITLE
chore(tests): remove redundant unit tests

### DIFF
--- a/tests/test_agent_modules/test_agent_core_responses.py
+++ b/tests/test_agent_modules/test_agent_core_responses.py
@@ -93,34 +93,12 @@ async def test_get_response_with_overrides(mock_runner_run, minimal_agent):
 
 @pytest.mark.asyncio
 async def test_get_response_missing_thread_manager():
-    """Test that get_response succeeds by creating minimal context for standalone agent."""
+    """Test that a standalone agent auto-creates minimal context."""
     agent = Agent(name="TestAgent", instructions="Test")
 
-    # The agent should successfully create a minimal context for standalone usage
     with patch("agents.Runner.run", new_callable=AsyncMock) as mock_runner:
         mock_runner.return_value = MagicMock(new_items=[], final_output="Test response")
 
-        # This should succeed by auto-creating necessary components
         result = await agent.get_response("Test message")
 
-        # Just verify the result exists - the agent handles ThreadManager internally
-        assert result is not None
-
-
-# --- Error Handling Tests ---
-
-
-@pytest.mark.asyncio
-async def test_call_before_agency_setup():
-    """Test that calling agent methods without agency setup succeeds by creating minimal context."""
-    agent = Agent(name="TestAgent", instructions="Test")
-
-    # The agent should auto-create necessary components for direct usage
-    with patch("agents.Runner.run", new_callable=AsyncMock) as mock_runner:
-        mock_runner.return_value = MagicMock(new_items=[], final_output="Test response")
-
-        # This should succeed by auto-creating minimal context
-        result = await agent.get_response("Test message")
-
-        # Just verify the result exists - the agent handles ThreadManager internally
         assert result is not None

--- a/tests/test_agent_modules/test_agent_initialization.py
+++ b/tests/test_agent_modules/test_agent_initialization.py
@@ -63,14 +63,6 @@ def test_agent_initialization_with_validator():
         assert not hasattr(agent, "response_validator")
 
 
-def test_agent_initialization_with_output_type():
-    """Test Agent initialization with output_type parameter."""
-    agent = Agent(name="Agent5", instructions="Structured output", output_type=TaskOutput)
-    assert agent.output_type == TaskOutput
-    assert agent.name == "Agent5"
-    assert agent.instructions == "Structured output"
-
-
 def test_agent_initialization_with_model_settings():
     """Test Agent initialization with a specific model."""
     agent = Agent(


### PR DESCRIPTION
## Summary
- drop duplicate standalone-agent check in core response tests
- remove redundant Agent initialization case covering output_type

## Testing
- `make ci` *(fails: Item "int" of "list[Any] | int | bool | Any | str | Model | None" has no attribute "append")*
- `uv run python examples/interactive/terminal_demo.py`
- `uv run python examples/multi_agent_workflow.py`
- `uv run pytest tests/integration/ -v`

------
https://chatgpt.com/codex/tasks/task_e_689d538bedc08323b179cbbc8d046cb1