### PR TITLE
tests: deduplicate tools folder invalid cases

### DIFF
--- a/tests/test_agent_modules/test_tool_system.py
+++ b/tests/test_agent_modules/test_tool_system.py
@@ -276,15 +276,10 @@ def valid_tool() -> str:
     assert len(tool_names) == 1
 
 
-def test_tools_folder_none():
-    """Test agent works with no tools_folder."""
-    agent = Agent(name="test", instructions="test", tools_folder=None)
-    assert agent.tools == []
-
-
-def test_tools_folder_nonexistent_path():
-    """Test agent handles nonexistent tools_folder gracefully."""
-    agent = Agent(name="test", instructions="test", tools_folder="/nonexistent/path")
+@pytest.mark.parametrize("folder_value", [None, "/nonexistent/path"])
+def test_tools_folder_invalid(folder_value: str | None):
+    """Agent handles missing or invalid tools_folder gracefully."""
+    agent = Agent(name="test", instructions="test", tools_folder=folder_value)
     assert agent.tools == []
 
 


### PR DESCRIPTION
## Summary
- parametrize invalid `tools_folder` inputs to remove redundant tests while preserving coverage

## Testing
- `make ci` *(fails: Item "int" of "list[Any] | int | bool | Any | str | Model | None" has no attribute "append" ...)*
- `uv run python examples/interactive/terminal_demo.py`
- `uv run python examples/multi_agent_workflow.py`
- `uv run pytest tests/integration/ -v`


------
https://chatgpt.com/codex/tasks/task_e_689eac34aac08323b8816da27134a8f2