### PR TITLE
tests: remove redundant streaming thread test

### DIFF
--- a/tests/test_agent_modules/test_ui_converters.py
+++ b/tests/test_agent_modules/test_ui_converters.py
@@ -3,6 +3,8 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+pytest.importorskip("ag_ui")
 from ag_ui.core import AssistantMessage, FunctionCall, ToolCall, ToolMessage, UserMessage
 from pydantic import BaseModel
 


### PR DESCRIPTION
## Summary
- drop unused `test_get_response_stream_generates_thread_id`
- assert stream output in remaining thread management test
- skip UI converter tests when `ag_ui` isn't installed

## Testing
- `make coverage` *(fails: AgentsException during integration tests)*
- `uv run pytest tests/test_agent_modules/test_agent_streaming.py tests/test_agent_modules/test_ui_converters.py -q`
- `uv run pytest tests/integration/test_agent_model_settings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689eac34aac08323b8816da27134a8f2