### PR TITLE
tests: streamline and deduplicate test suite

### DIFF
--- a/tests/integration/test_agency_context_sharing.py
+++ b/tests/integration/test_agency_context_sharing.py
@@ -5,7 +5,6 @@ This test verifies that agents can share data through the agency context,
 ensuring that changes made by one agent are visible to other agents.
 """
 
-import asyncio
 
 import pytest
 from agents import RunContextWrapper, function_tool
@@ -90,7 +89,3 @@ async def test_context_sharing_between_agents():
         recipient_agent=agent2,
     )
     assert "agent2_value" in response4.final_output
-
-
-if __name__ == "__main__":
-    asyncio.run(test_context_sharing_between_agents())

--- a/tests/integration/test_context_persistence.py
+++ b/tests/integration/test_context_persistence.py
@@ -5,7 +5,6 @@ This test verifies that modifications to user_context are preserved
 between different agent invocations within the same agency.
 """
 
-import asyncio
 
 import pytest
 from pydantic import Field
@@ -104,7 +103,3 @@ async def test_context_override_does_not_affect_agency():
     # Verify agency context was NOT modified
     assert "override_key" not in agency.user_context
     assert agency.user_context == {"agency_key": "agency_value"}
-
-
-if __name__ == "__main__":
-    asyncio.run(test_context_persistence_between_calls())

--- a/tests/integration/test_multi_agency_support.py
+++ b/tests/integration/test_multi_agency_support.py
@@ -259,7 +259,3 @@ class TestStatelessContextPassing:
         # Invalid agent name should raise error
         with pytest.raises(ValueError, match="No context found for agent"):
             agency1._get_agent_context("NonexistentAgent")
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/tests/integration/test_vector_store_citation_extraction.py
+++ b/tests/integration/test_vector_store_citation_extraction.py
@@ -9,7 +9,6 @@ not direct file attachment citations which are tested separately.
 """
 
 import asyncio
-import os
 import tempfile
 from pathlib import Path
 
@@ -97,10 +96,3 @@ Equipment Status: Mass Spectrometer operational
         print(f"   File ID: {citation['file_id']}")
         print(f"   Tool Call: {citation['tool_call_id']}")
         print(f"   Content preview: {citation['text'][:50]}...")
-
-
-if __name__ == "__main__":
-    # Allow running this test directly
-    if os.name == "nt":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    asyncio.run(test_vector_store_citation_extraction())

--- a/tests/test_agent_modules/test_thread_manager.py
+++ b/tests/test_agent_modules/test_thread_manager.py
@@ -1,5 +1,7 @@
 import pickle
 
+import pytest
+
 from agency_swarm.thread import ThreadManager
 
 
@@ -11,34 +13,49 @@ def test_thread_manager_initialization():
     assert manager._save_threads_callback is None
 
 
-def test_add_message():
-    """Tests adding a single message to the thread manager."""
+@pytest.mark.parametrize(
+    "method,messages",
+    [
+        (
+            "add_message",
+            [
+                {
+                    "role": "user",
+                    "content": "Hello",
+                    "agent": "Agent1",
+                    "callerAgent": None,
+                    "timestamp": 1234567890000,
+                }
+            ],
+        ),
+        (
+            "add_messages",
+            [
+                {
+                    "role": "user",
+                    "content": "Hello",
+                    "agent": "Agent1",
+                    "callerAgent": None,
+                    "timestamp": 1234567890000,
+                },
+                {
+                    "role": "assistant",
+                    "content": "Hi there",
+                    "agent": "Agent1",
+                    "callerAgent": None,
+                    "timestamp": 1234567891000,
+                },
+            ],
+        ),
+    ],
+)
+def test_add_messages(method: str, messages: list[dict]):
+    """Tests adding messages through both single and batch methods."""
     manager = ThreadManager()
-    message = {"role": "user", "content": "Hello", "agent": "Agent1", "callerAgent": None, "timestamp": 1234567890000}
+    target = messages[0] if method == "add_message" else messages
+    getattr(manager, method)(target)
 
-    manager.add_message(message)
-
-    assert len(manager._store.messages) == 1
-    assert manager._store.messages[0] == message
-
-
-def test_add_messages():
-    """Tests adding multiple messages to the thread manager."""
-    manager = ThreadManager()
-    messages = [
-        {"role": "user", "content": "Hello", "agent": "Agent1", "callerAgent": None, "timestamp": 1234567890000},
-        {
-            "role": "assistant",
-            "content": "Hi there",
-            "agent": "Agent1",
-            "callerAgent": None,
-            "timestamp": 1234567891000,
-        },
-    ]
-
-    manager.add_messages(messages)
-
-    assert len(manager._store.messages) == 2
+    assert len(manager._store.messages) == len(messages)
     assert manager._store.messages == messages
 
 

--- a/tests/test_agent_modules/test_tool_system.py
+++ b/tests/test_agent_modules/test_tool_system.py
@@ -276,15 +276,10 @@ def valid_tool() -> str:
     assert len(tool_names) == 1
 
 
-def test_tools_folder_none():
-    """Test agent works with no tools_folder."""
-    agent = Agent(name="test", instructions="test", tools_folder=None)
-    assert agent.tools == []
-
-
-def test_tools_folder_nonexistent_path():
-    """Test agent handles nonexistent tools_folder gracefully."""
-    agent = Agent(name="test", instructions="test", tools_folder="/nonexistent/path")
+@pytest.mark.parametrize("folder", [None, "/nonexistent/path"])
+def test_tools_folder_missing(folder: str | None):
+    """Agent should handle missing or invalid tools_folder gracefully."""
+    agent = Agent(name="test", instructions="test", tools_folder=folder)
     assert agent.tools == []
 
 


### PR DESCRIPTION
## Summary
- parameterize thread manager message tests to remove duplicate coverage
- merge tools folder edge-case checks into one parametrized test
- drop stray `__main__` execution blocks from integration tests

## Testing
- `make ci` *(fails: Item "int" of "list[Any] | int | bool | Any | str | Model | None" has no attribute "append")*
- `uv run python examples/interactive/terminal_demo.py`
- `uv run python examples/multi_agent_workflow.py`
- `uv run pytest tests/integration/ -v` *(partial, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689eac34aac08323b8816da27134a8f2