### PR TITLE
fix: correct optional type annotations

### DIFF
--- a/src/agency_swarm/agent/file_manager.py
+++ b/src/agency_swarm/agent/file_manager.py
@@ -476,7 +476,7 @@ class AgentFileManager:
         if code_interpreter_file_ids:
             self.add_code_interpreter_tool(code_interpreter_file_ids)
 
-    def add_file_search_tool(self, vector_store_id: str, file_ids: list[str] = None):
+    def add_file_search_tool(self, vector_store_id: str, file_ids: list[str] | None = None):
         """
         Adds a new vector store to the existing FileSearchTool or creates a new one if it doesn't exist.
         If optional file_ids provided, they will be added to the provided vector store.

--- a/src/agency_swarm/integrations/fastapi_utils/request_models.py
+++ b/src/agency_swarm/integrations/fastapi_utils/request_models.py
@@ -16,8 +16,8 @@ class RunAgentInputCustom(RunAgentInput):
     Input for running an agent.
     """
 
-    chat_history: list[dict[str, Any]] = Field(
-        None,
+    chat_history: list[dict[str, Any]] | None = Field(
+        default=None,
         description=(
             "Entire chat history as a flat list of messages. "
             "Each message should contain 'agent', 'callerAgent', 'timestamp' and other OpenAI fields."
@@ -27,23 +27,23 @@ class RunAgentInputCustom(RunAgentInput):
 
 class BaseRequest(BaseModel):
     message: str
-    chat_history: list[dict[str, Any]] = Field(
-        None,
+    chat_history: list[dict[str, Any]] | None = Field(
+        default=None,
         description=(
             "Entire chat history as a flat list of messages. "
             "Each message should contain 'agent', 'callerAgent', 'timestamp' and other OpenAI fields."
         ),
     )
-    recipient_agent: str = None
-    file_ids: list[str] = None
-    file_urls: dict[str, str] = Field(
-        None,
+    recipient_agent: str | None = None
+    file_ids: list[str] | None = None
+    file_urls: dict[str, str] | None = Field(
+        default=None,
         description=(
             "List of downloadable file urls to be use as file attachments. "
             "Should be provided in a form of {'file_name_1': 'download_url_1', 'file_name_2': 'download_url_2', ...}"
         ),
     )
-    additional_instructions: str = None
+    additional_instructions: str | None = None
 
 
 class LogRequest(BaseModel):

--- a/src/agency_swarm/tools/BaseTool.py
+++ b/src/agency_swarm/tools/BaseTool.py
@@ -29,7 +29,7 @@ class classproperty:
 class BaseTool(BaseModel, ABC):
     _caller_agent: Any = None
     _event_handler: Any = None
-    _tool_call: ToolCall = None
+    _tool_call: ToolCall | None = None
     _context: Any = None  # Will hold RunContextWrapper when available
     openai_schema: ClassVar[dict[str, Any]]
 

--- a/src/agency_swarm/utils/citation_extractor.py
+++ b/src/agency_swarm/utils/citation_extractor.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def extract_direct_file_annotations(
-    assistant_messages: list[MessageOutputItem], agent_name: str = None
+    assistant_messages: list[MessageOutputItem], agent_name: str | None = None
 ) -> dict[str, list[dict]]:
     """
     Extract file citations from direct file uploads (annotations in message content).

--- a/tests/integration/test_terminal_demo_like.py
+++ b/tests/integration/test_terminal_demo_like.py
@@ -23,7 +23,8 @@ async def test_terminal_demo_like_flow():
         name="CEO",
         description="Chief Executive Officer - oversees all operations",
         instructions=(
-            "You are the CEO. When asked about weather, delegate to Worker with a specific location (use London if not specified)."
+            "You are the CEO. When asked about weather, delegate to Worker "
+            "with a specific location (use London if not specified)."
         ),
         tools=[],
         model_settings=ModelSettings(temperature=0.0),


### PR DESCRIPTION
## Summary
- ensure request models and tooling handle optional inputs with explicit `| None`
- align citation extractor parameter with optional type usage
- adjust test fixture for lint compliance

## Testing
- `make ci` *(fails: mypy union-attr errors)*
- `uv run python examples/interactive/terminal_demo.py`
- `uv run python examples/multi_agent_workflow.py`
- `uv run pytest tests/integration/ -v` *(interrupted after partial pass)*
- `uv run python examples/streaming.py`
- `uv run pytest tests/integration/test_streaming_order_consistency.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e95772088323b9db25a3e593da17