### PR TITLE
agent: drop auto file search and temp vector stores

### DIFF
--- a/examples/file_search.py
+++ b/examples/file_search.py
@@ -3,7 +3,7 @@
 Simple FileSearch Example - Agency Swarm v1.x
 
 This example demonstrates how to use the FileSearch tool with citations.
-The agent automatically creates a vector store and indexes files for search.
+The agent indexes PDF files for search; FileSearch must be added explicitly.
 """
 
 import asyncio
@@ -28,13 +28,13 @@ async def main():
     examples_dir = Path(__file__).parent
     docs_dir = examples_dir / "data"
 
-    if not docs_dir.exists() or not list(docs_dir.glob("*.txt")):
-        print(f"❌ Error: No .txt files found in: {docs_dir}")
-        print("   Please ensure there are research files in the data directory.")
+    if not docs_dir.exists() or not list(docs_dir.glob("*.pdf")):
+        print(f"❌ Error: No .pdf files found in: {docs_dir}")
+        print("   Please ensure there are PDF files in the data directory.")
         return
 
-    txt_files = list(docs_dir.glob("*.txt"))
-    print(f"📁 Found {len(txt_files)} research file(s) in: {docs_dir}")
+    pdf_files = list(docs_dir.glob("*.pdf"))
+    print(f"📁 Found {len(pdf_files)} PDF file(s) in: {docs_dir}")
 
     # Create an agent that can search files with citations
     search_agent = Agent(
@@ -43,6 +43,9 @@ async def main():
         files_folder=str(docs_dir),
         include_search_results=True,  # Enable citation extraction
     )
+    # FileSearch is no longer added automatically; add it explicitly
+    if search_agent._associated_vector_store_id:
+        search_agent.file_manager.add_file_search_tool(search_agent._associated_vector_store_id)
 
     # Create agency
     agency = Agency(
@@ -55,7 +58,7 @@ async def main():
     await asyncio.sleep(3)
 
     # Test search with a specific question
-    question = "What is the badge number for Marcus Chen?"
+    question = "What is the secret phrase in the PDF file?"
     print(f"\n❓ Question: {question}")
 
     try:
@@ -67,7 +70,7 @@ async def main():
         display_citations(citations, "vector store")
 
         # Check if we got the expected answer
-        if "7401" in response.final_output:
+        if "FIRST PDF SECRET PHRASE" in response.final_output.upper():
             print("✅ Correct answer found!")
         else:
             print("ℹ️  Try different questions from the research data")
@@ -76,7 +79,7 @@ async def main():
         print(f"❌ Error: {e}")
 
     print("\n🎯 Usage Tips:")
-    print("   • Add more .txt files to the data/ directory")
+    print("   • Add more .pdf files to the data/ directory")
     print("   • Citations show which files contain the answers")
     print("   • Vector store persists between runs")
 

--- a/examples/file_search_persistence.py
+++ b/examples/file_search_persistence.py
@@ -56,9 +56,16 @@ async def run_hosted_tool_preservation_demo():
     # Create test data file
     with tempfile.TemporaryDirectory(prefix="hosted_tool_test_") as test_data_dir_str:
         test_data_dir = Path(test_data_dir_str)
-        test_file = test_data_dir / "sales_report.txt"
-        test_file.write_text("""
-QUARTERLY SALES REPORT Q4 2024
+        test_file = test_data_dir / "sales_report.pdf"
+        from fpdf import FPDF
+
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        pdf.multi_cell(
+            0,
+            10,
+            """QUARTERLY SALES REPORT Q4 2024
 
 Performance Metrics:
 - Total Revenue: $5,678,901.23
@@ -75,8 +82,9 @@ Top Products:
 Regional Performance:
 - North America: $2,890,123.45
 - Europe: $1,567,890.12
-- Asia Pacific: $1,220,887.66
-""")
+- Asia Pacific: $1,220,887.66""",
+        )
+        pdf.output(str(test_file))
 
         # Create agent with FileSearch capability
         file_search_agent = Agent(
@@ -85,6 +93,8 @@ Regional Performance:
             files_folder=str(test_data_dir),
             model_settings=ModelSettings(temperature=0.0),
         )
+        if file_search_agent._associated_vector_store_id:
+            file_search_agent.file_manager.add_file_search_tool(file_search_agent._associated_vector_store_id)
 
         # Create agency with hosted tool agent
         hosted_tool_agency = Agency(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev-dependencies = [
     "pytest-asyncio>=1.0.0",
     "pytest-mock>=3.14.1",
     "ruff>=0.11.12",
+    "fpdf>=1.7.2,<2",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/agency_swarm/agent/initialization.py
+++ b/src/agency_swarm/agent/initialization.py
@@ -126,8 +126,7 @@ def handle_deprecated_parameters(kwargs: dict[str, Any]) -> dict[str, Any]:
 
     if "file_search" in kwargs:
         warnings.warn(
-            "'file_search' parameter is deprecated. FileSearchTool is added automatically "
-            "if 'files_folder' indicates a Vector Store.",
+            "'file_search' parameter is deprecated. FileSearchTool must be added manually if desired.",
             DeprecationWarning,
             stacklevel=3,
         )

--- a/src/agency_swarm/agent_core.py
+++ b/src/agency_swarm/agent_core.py
@@ -80,7 +80,7 @@ class Agent(BaseAgent[MasterContext]):
         files_folder (str | Path | None): Path to a local folder for managing files associated with this agent.
                                           If the folder name follows the pattern `*_vs_<vector_store_id>`,
                                           files uploaded via `upload_file` will also be added to the specified
-                                          OpenAI Vector Store, and a `FileSearchTool` will be automatically added.
+                                          OpenAI Vector Store.
         tools_folder (str | Path | None): Path to a directory containing tool definitions. Tools are automatically
                                            discovered and loaded from this directory. Supports both BaseTool
                                            subclasses and FunctionTool instances. Python files starting with
@@ -148,8 +148,7 @@ class Agent(BaseAgent[MasterContext]):
             output_guardrails (list[OutputGuardrail] | None): Output validation rules.
             mcp_servers (list[MCPServer] | None): Model Context Protocol servers.
             files_folder (str | Path | None): Path to a folder of files associated with this agent. If the folder name
-                matches `*_vs_<vector_store_id>`, uploaded files are added to the specified OpenAI Vector Store and a
-                FileSearch tool is added automatically.
+                matches `*_vs_<vector_store_id>`, uploaded files are added to the specified OpenAI Vector Store.
             tools_folder (str | Path | None): Path to a directory containing tool definitions.
             schemas_folder (str | Path | list[str | Path] | None): Path(s) to directories containing OpenAPI schema
                 files for automatic tool generation.

--- a/tests/integration/test_responses_api_tools.py
+++ b/tests/integration/test_responses_api_tools.py
@@ -274,9 +274,16 @@ async def test_hosted_tool_output_preservation_multi_turn():
     # Create test data with specific content
     with tempfile.TemporaryDirectory(prefix="hosted_tool_test_") as temp_dir_str:
         temp_dir = Path(temp_dir_str)
-        test_file = temp_dir / "company_data.txt"
-        test_file.write_text("""
-COMPANY FINANCIAL REPORT
+        test_file = temp_dir / "company_data.pdf"
+        from fpdf import FPDF
+
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        pdf.multi_cell(
+            0,
+            10,
+            """COMPANY FINANCIAL REPORT
 
 Revenue Information:
 - Q4 Revenue: $7,892,345.67
@@ -292,8 +299,9 @@ Employee Data:
 Product Sales:
 - Product Alpha: 12,345 units
 - Product Beta: 6,789 units
-- Product Gamma: 2,345 units
-""")
+- Product Gamma: 2,345 units""",
+        )
+        pdf.output(str(test_file))
 
         # Create Agency Swarm agent with FileSearch via files_folder
         agent = AgencySwarmAgent(
@@ -307,6 +315,8 @@ Product Sales:
             files_folder=str(temp_dir),
             include_search_results=True,
         )
+        if agent._associated_vector_store_id:
+            agent.file_manager.add_file_search_tool(agent._associated_vector_store_id)
 
         # Create an agency with the agent
         agency = Agency(agent)

--- a/tests/integration/test_terminal_demo_like.py
+++ b/tests/integration/test_terminal_demo_like.py
@@ -23,7 +23,8 @@ async def test_terminal_demo_like_flow():
         name="CEO",
         description="Chief Executive Officer - oversees all operations",
         instructions=(
-            "You are the CEO. When asked about weather, delegate to Worker with a specific location (use London if not specified)."
+            "You are the CEO. When asked about weather, delegate to Worker "
+            "with a specific location (use London if not specified)."
         ),
         tools=[],
         model_settings=ModelSettings(temperature=0.0),

--- a/tests/integration/test_vector_store_citation_extraction.py
+++ b/tests/integration/test_vector_store_citation_extraction.py
@@ -30,19 +30,25 @@ async def test_vector_store_citation_extraction():
     # Create temporary directory and test file
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
-        test_file = temp_path / "research_document.txt"
+        test_file = temp_path / "research_document.pdf"
+        from fpdf import FPDF
 
-        # Create a test document with specific content
-        test_content = """RESEARCH REPORT - TEST DATA
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        pdf.multi_cell(
+            0,
+            10,
+            """RESEARCH REPORT - TEST DATA
 
 Project Code: TEST-123
 Researcher: Dr. Jane Smith
 Badge Number: 9876
 Experiment Results: Compound XYZ-456 synthesized successfully
 Yield Efficiency: 95.2%
-Equipment Status: Mass Spectrometer operational
-"""
-        test_file.write_text(test_content)
+Equipment Status: Mass Spectrometer operational""",
+        )
+        pdf.output(str(test_file))
 
         # Create agent with FileSearch capability and citations enabled
         search_agent = Agent(
@@ -54,6 +60,8 @@ Equipment Status: Mass Spectrometer operational
             files_folder=str(temp_path),
             include_search_results=True,
         )
+        if search_agent._associated_vector_store_id:
+            search_agent.file_manager.add_file_search_tool(search_agent._associated_vector_store_id)
 
         # Create agency
         agency = Agency(

--- a/tests/test_agent_modules/test_agent_initialization.py
+++ b/tests/test_agent_modules/test_agent_initialization.py
@@ -88,7 +88,7 @@ def test_agent_initialization_with_all_parameters():
     tool1 = MagicMock(spec=FunctionTool)
     tool1.name = "tool1"
 
-    # TEST-ONLY SETUP: Create test directory to enable FileSearchTool auto-addition
+    # TEST-ONLY SETUP: Create test directory for files_folder functionality
     import tempfile
     from pathlib import Path
     from unittest.mock import PropertyMock, patch
@@ -130,7 +130,7 @@ def test_agent_initialization_with_all_parameters():
         assert agent.model == "gpt-4.1"
         assert len(agent.tools) == 2
         assert agent.tools[0] == tool1
-        assert agent.tools[1].__class__.__name__ == "FileSearchTool"
+        assert agent.tools[1].__class__.__name__ == "CodeInterpreterTool"
         # response_validator is completely removed
         assert not hasattr(agent, "response_validator")
         assert agent.output_type == TaskOutput

--- a/uv.lock
+++ b/uv.lock
@@ -60,6 +60,7 @@ voice = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "fpdf" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -102,6 +103,7 @@ provides-extras = ["voice", "viz", "litellm", "fastapi"]
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.8.2" },
+    { name = "fpdf", specifier = ">=1.7.2,<2" },
     { name = "mypy", specifier = ">=1.16.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.4.0" },
@@ -456,7 +458,7 @@ version = "3.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4.0'" },
+    { name = "docstring-parser", marker = "python_full_version < '4'" },
     { name = "rich" },
     { name = "rich-rst" },
 ]
@@ -616,6 +618,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f25
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
 ]
+
+[[package]]
+name = "fpdf"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/c6/608a9e6c172bf9124aa687ec8b9f0e8e5d697d59a5f4fad0e2d5ec2a7556/fpdf-1.7.2.tar.gz", hash = "sha256:125840783289e7d12552b1e86ab692c37322e7a65b96a99e0ea86cca041b6779", size = 39504, upload-time = "2015-01-21T00:07:47.493Z" }
 
 [[package]]
 name = "frozenlist"


### PR DESCRIPTION
## Summary
- handle non-PDF attachments with Code Interpreter only
- stop auto-registering FileSearch and remove temp vector stores
- update examples and tests to use PDF files and explicit FileSearch setup

## Testing
- `make ci` *(fails: mypy type errors in unrelated modules)*
- `make tests`
- `uv run python examples/file_search.py`
- `uv run python examples/file_search_persistence.py`


------
https://chatgpt.com/codex/tasks/task_e_68a01443bb8883239e8eba6f42d7c9e0