### PR TITLE
thread: share user conversation across agents

### DIFF
--- a/src/agency_swarm/thread.py
+++ b/src/agency_swarm/thread.py
@@ -175,15 +175,24 @@ class ThreadManager:
         self._save_messages()
 
     def get_conversation_history(self, agent: str, caller_agent: str | None = None) -> list[TResponseInputItem]:
-        """Get conversation history for a specific agent pair.
+        """Get conversation history for a specific interaction pair.
+
+        When ``caller_agent`` is ``None`` (user conversation), returns the shared user
+        thread containing all messages where ``callerAgent`` is ``None`` regardless of
+        the recipient agent. This ensures that all entry-point agents operate on the
+        same user thread.
 
         Args:
-            agent: The recipient agent
-            caller_agent: The sender agent (None for user)
+            agent: The recipient agent (ignored for user thread retrieval)
+            caller_agent: The sender agent (``None`` for user interactions)
 
         Returns:
             list[TResponseInputItem]: Relevant conversation history
         """
+        if caller_agent is None:
+            messages = self._store.get_messages()
+            return [m for m in messages if m.get("callerAgent") is None]
+
         return self._store.get_conversation_between(agent, caller_agent)
 
     def get_all_messages(self) -> list[TResponseInputItem]:

--- a/tests/test_agent_modules/test_thread_manager.py
+++ b/tests/test_agent_modules/test_thread_manager.py
@@ -59,8 +59,8 @@ def test_add_messages(method: str, messages: list[dict]):
     assert manager._store.messages == messages
 
 
-def test_get_conversation_history():
-    """Tests retrieving conversation history for specific agent pairs."""
+def test_user_thread_shared_across_agents():
+    """Tests that all entry-point agents share the same user thread."""
     manager = ThreadManager()
     messages = [
         {"role": "user", "content": "Hello Agent1", "agent": "Agent1", "callerAgent": None, "timestamp": 1234567890000},
@@ -77,15 +77,13 @@ def test_get_conversation_history():
 
     manager.add_messages(messages)
 
-    # Get conversation between user and Agent1
+    # Both agents should see the same combined conversation history
     agent1_history = manager.get_conversation_history("Agent1", None)
-    assert len(agent1_history) == 2
-    assert all(msg["agent"] == "Agent1" for msg in agent1_history)
-
-    # Get conversation between user and Agent2
     agent2_history = manager.get_conversation_history("Agent2", None)
-    assert len(agent2_history) == 2
-    assert all(msg["agent"] == "Agent2" for msg in agent2_history)
+
+    assert agent1_history == messages
+    assert agent2_history == messages
+    assert agent1_history == agent2_history
 
 
 def test_get_all_messages():


### PR DESCRIPTION
## Summary
- ensure all entry-point agents share a single user thread
- update tests to validate shared user history

## Testing
- `make ci` *(fails: mypy type errors)*
- `uv run python examples/interactive/terminal_demo.py`
- `uv run python examples/multi_agent_workflow.py`
- `uv run pytest tests/integration/ -v` *(interrupted)*
- `uv run python examples/streaming.py`
- `uv run pytest tests/integration/test_streaming_order_consistency.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7439be6c08323999666efc0182f13