### PR TITLE
tools: relax OpenAPI validation for summary-only operations

### DIFF
--- a/src/agency_swarm/tools/utils.py
+++ b/src/agency_swarm/tools/utils.py
@@ -36,7 +36,7 @@ def from_openapi_schema(
         headers (dict[str, str] | None, optional): Extra HTTP headers to send with each call. Defaults to None.
         params (dict[str, Any] | None, optional): Extra query parameters to append to every call. Defaults to None.
         strict (bool, optional): If True, sets 'additionalProperties' to False in every generated schema.
-            Defaults to True.
+            Defaults to False.
         timeout (int, optional): HTTP timeout in seconds. Defaults to 90.
 
     Returns:
@@ -168,7 +168,15 @@ def from_openapi_schema(
     return tools
 
 
-def validate_openapi_spec(spec: str):
+def validate_openapi_spec(spec: str) -> dict:
+    """Validate minimal structure of an OpenAPI specification.
+
+    The spec must contain a ``paths`` dictionary. Each path item must be a
+    mapping where operations include an ``operationId`` and at least one of
+    ``description`` or ``summary``.
+
+    Returns the parsed specification dictionary if validation succeeds.
+    """
     spec_dict = json.loads(spec)
 
     # Validate that 'paths' is present in the spec
@@ -188,8 +196,8 @@ def validate_openapi_spec(spec: str):
             # Basic validation for each operation
             if "operationId" not in operation:
                 raise ValueError("Each operation must contain an 'operationId'.")
-            if "description" not in operation:
-                raise ValueError("Each operation must contain a 'description'.")
+            if "description" not in operation and "summary" not in operation:
+                raise ValueError("Each operation must contain a 'description' or 'summary'.")
 
     return spec_dict
 

--- a/tests/test_agent_modules/test_tools_utils.py
+++ b/tests/test_agent_modules/test_tools_utils.py
@@ -164,10 +164,14 @@ class TestValidateOpenAPISpec:
         "spec,should_pass",
         [
             ({"paths": {"/users": {"get": {"operationId": "getUsers", "description": "Get users"}}}}, True),
+            (
+                {"paths": {"/users": {"get": {"operationId": "getUsers", "summary": "Get users"}}}},
+                True,
+            ),
             ({"info": {"title": "API"}}, False),  # Missing paths
             ({"paths": {"/users": "invalid"}}, False),  # Invalid path item
             ({"paths": {"/users": {"get": {"description": "Get users"}}}}, False),  # Missing operationId
-            ({"paths": {"/users": {"get": {"operationId": "getUsers"}}}}, False),  # Missing description
+            ({"paths": {"/users": {"get": {"operationId": "getUsers"}}}}, False),  # Missing description and summary
         ],
     )
     def test_validation(self, spec, should_pass):


### PR DESCRIPTION
## Summary
- accept `summary` in `validate_openapi_spec`
- correct `strict` default documentation in `from_openapi_schema`
- expand tests to cover summary-only operations

## Testing
- `uv run pytest tests/test_agent_modules/test_tools_utils.py::TestValidateOpenAPISpec::test_validation -q`
- `make ci` *(fails: tests/integration/test_communication.py::test_non_blocking_parallel_agent_interactions, tests/integration/test_thread_isolation_basic.py::test_agent_to_agent_thread_isolation)*
- `uv run pytest tests/integration/ -v` *(fails: tests/integration/test_thread_isolation_basic.py::test_agent_to_agent_thread_isolation)*
- `uv run python examples/streaming.py`

------
https://chatgpt.com/codex/tasks/task_e_68afca84004883238e4fed839b18996d