### PR TITLE
tools: allow summary in OpenAPI validation

### DIFF
--- a/src/agency_swarm/tools/utils.py
+++ b/src/agency_swarm/tools/utils.py
@@ -188,8 +188,8 @@ def validate_openapi_spec(spec: str):
             # Basic validation for each operation
             if "operationId" not in operation:
                 raise ValueError("Each operation must contain an 'operationId'.")
-            if "description" not in operation:
-                raise ValueError("Each operation must contain a 'description'.")
+            if "description" not in operation and "summary" not in operation:
+                raise ValueError("Each operation must contain a 'description' or 'summary'.")
 
     return spec_dict
 

--- a/tests/test_agent_modules/test_tools_utils.py
+++ b/tests/test_agent_modules/test_tools_utils.py
@@ -164,10 +164,14 @@ class TestValidateOpenAPISpec:
         "spec,should_pass",
         [
             ({"paths": {"/users": {"get": {"operationId": "getUsers", "description": "Get users"}}}}, True),
+            ({"paths": {"/users": {"get": {"operationId": "getUsers", "summary": "Get users"}}}}, True),
             ({"info": {"title": "API"}}, False),  # Missing paths
             ({"paths": {"/users": "invalid"}}, False),  # Invalid path item
             ({"paths": {"/users": {"get": {"description": "Get users"}}}}, False),  # Missing operationId
-            ({"paths": {"/users": {"get": {"operationId": "getUsers"}}}}, False),  # Missing description
+            (
+                {"paths": {"/users": {"get": {"operationId": "getUsers"}}}},
+                False,
+            ),  # Missing description and summary
         ],
     )
     def test_validation(self, spec, should_pass):


### PR DESCRIPTION
## Summary
- relax OpenAPI spec validation to accept `summary` when `description` is absent
- cover summary-only endpoint definitions in validation tests

## Testing
- `uv run pytest tests/test_agent_modules/test_tools_utils.py -q`
- `make ci` *(fails: make: *** [Makefile:46: tests] Error 143)*
- `uv run pytest tests/integration/ -v` *(fails: KeyboardInterrupt)*
- `uv run python examples/streaming.py`

------
https://chatgpt.com/codex/tasks/task_e_68b255fb6e948323ac31d0fa030e63f8