### PR TITLE
chore: remove inflated wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Agency Swarm enhances the underlying SDK by introducing:
 - A specialized `send_message` tool automatically configured for agents, enabling them to communicate based on the defined communication flows.
 - `agency_swarm.Agent` which extends the base SDK `Agent` with built-in file handling and sub-agent registration capabilities.
 
-This framework continues the original vision of Arsenii Shatokhin (aka VRSEN) to simplify the creation of sophisticated AI agencies by thinking about automation in terms of real-world organizational structures, making it intuitive for both agents and users.
+This framework continues the original vision of Arsenii Shatokhin (aka VRSEN) to simplify the creation of AI agencies by thinking about automation in terms of real-world organizational structures, making it intuitive for both agents and users.
 
 **Migrating from v0.x?** Please see our [Migration Guide](./docs/migration/guide.mdx) for details on adapting your project to this new SDK-based version.
 
@@ -28,10 +28,10 @@ This framework continues the original vision of Arsenii Shatokhin (aka VRSEN) to
 
 - **Customizable Agent Roles**: Define distinct agent roles (e.g., CEO, Virtual Assistant, Developer) with tailored instructions, tools, and capabilities within the Agency Swarm framework, leveraging the underlying OpenAI Agents SDK.
 - **Full Control Over Agent Instructions**: Maintain complete control over each agent's guiding prompts (instructions) for precise behavior customization.
-- **Type-Safe Tools**: Develop robust tools using Pydantic models for automatic argument validation, compatible with the OpenAI Agents SDK's `FunctionTool` format.
+- **Type-Safe Tools**: Develop tools using Pydantic models for automatic argument validation, compatible with the OpenAI Agents SDK's `FunctionTool` format.
 - **Orchestrated Agent Communication**: Agents communicate via a dedicated `send_message` tool, with interactions governed by explicit `communication_flows` (directional) defined on the `Agency`.
 - **Flexible State Persistence**: Manage conversation history by providing `load_threads_callback` and `save_threads_callback` functions to the `Agency`. This allows for loading and saving conversation threads to external storage, enabling persistence across sessions.
-- **Robust Multi-Agent Orchestration**: Build complex and reliable agent workflows by leveraging the OpenAI Agents SDK foundation, enhanced by Agency Swarm's structured orchestration layer.
+- **Multi-Agent Orchestration**: Build agent workflows by leveraging the OpenAI Agents SDK foundation, enhanced by Agency Swarm's structured orchestration layer.
 - **Production-Ready Focus**: Built for reliability and designed for easy deployment in real-world environments.
 
 ## Installation

--- a/docs/additional-features/agency-context.mdx
+++ b/docs/additional-features/agency-context.mdx
@@ -22,7 +22,7 @@ Agency context is particularly useful when your agents interact with multiple to
 
 ![Without Agency Context](/images/shared-state-without.png)
 
-- **With Agency Context**: `Tool A` can store the required data in the agency context, and `Tool B` can retrieve it without needing direct parameter passing. This approach reduces complexity, saves tokens, and enables more sophisticated workflows.
+- **With Agency Context**: `Tool A` can store the required data in the agency context, and `Tool B` can retrieve it without needing direct parameter passing. This approach reduces complexity, saves tokens, and enables additional workflows.
 
 ![With Agency Context](/images/shared-state-with.png)
 
@@ -131,7 +131,7 @@ Agency context can store any Python object, making it perfect for complex workfl
 ```python
 @function_tool
 async def analyze_market_data(ctx: RunContextWrapper[MasterContext], symbols: str) -> str:
-    """Analyzes multiple stocks and stores comprehensive data."""
+    """Analyzes multiple stocks and stores data."""
     symbol_list = symbols.split(',')
 
     market_analysis = {
@@ -302,7 +302,7 @@ async def my_tool(ctx: RunContextWrapper[MasterContext], param: str) -> str:
 
 ## Example: Complete Workflow
 
-For a comprehensive example showing agency context in action, see the [Agency Context Workflow Example](/examples/agency_context_workflow.py) which demonstrates:
+For a full example showing agency context in action, see the [Agency Context Workflow Example](/examples/agency_context_workflow.py) which demonstrates:
 
 - Multi-step data collection and analysis
 - Cross-agent data sharing
@@ -310,4 +310,4 @@ For a comprehensive example showing agency context in action, see the [Agency Co
 - Workflow coordination
 - Context monitoring and debugging
 
-Agency context eliminates the need for complex parameter passing and enables sophisticated multi-agent workflows while maintaining clean separation of concerns.
+Agency context eliminates the need for complex parameter passing and enables multi-agent workflows while maintaining clean separation of concerns.

--- a/docs/additional-features/custom-communication-flows/hybrid-patterns.mdx
+++ b/docs/additional-features/custom-communication-flows/hybrid-patterns.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Hybrid Patterns: Combining SendMessage and Handoffs"
-description: "Learn how to effectively combine Agency Swarm's SendMessage tools with OpenAI SDK Handoffs for sophisticated multi-agent coordination."
+description: "Learn how to effectively combine Agency Swarm's SendMessage tools with OpenAI SDK Handoffs for multi-agent coordination."
 icon: "arrows-split-up-and-left"
 ---
 <Warning>
 This page only applies to newer versions of the framework (v1.x and higher)
 </Warning>
 
-Agency Swarm supports two powerful paradigms for inter-agent communication that can work together seamlessly: **SendMessage tools** (orchestrator pattern) and **OpenAI SDK Handoffs** (sequential pattern). This guide explains how these patterns interact and provides practical examples for building sophisticated multi-agent systems.
+Agency Swarm supports two paradigms for inter-agent communication that can work together seamlessly: **SendMessage tools** (orchestrator pattern) and **OpenAI SDK Handoffs** (sequential pattern). This guide explains how these patterns interact and provides practical examples for building multi-agent systems.
 
 <CardGroup cols={2}>
   <Card title="SendMessage Tools" icon="arrow-right-arrow-left">
@@ -154,8 +154,8 @@ agency = Agency(
 
 ## Conclusion
 
-Agency Swarm's hybrid paradigm resolution enables sophisticated multi-agent architectures that would be difficult to achieve with either pattern alone.
-By understanding how SendMessage tools and Sequential Handoffs work together, you can build powerful systems that combine the best of both orchestration
+Agency Swarm's hybrid paradigm resolution enables multi-agent architectures that would be difficult to achieve with either pattern alone.
+By understanding how SendMessage tools and Sequential Handoffs work together, you can build systems that combine the best of both orchestration
 and sequential delegation patterns, giving you the flexibility to design complex multi-agent workflows.
 
 <Note>

--- a/docs/additional-features/observability.mdx
+++ b/docs/additional-features/observability.mdx
@@ -27,7 +27,7 @@ Agency Swarm supports three main observability approaches:
 
 ## Getting Started
 
-Let's walk through setting up each tracing solution. You can use them individually or combine them for comprehensive monitoring.
+Let's walk through setting up each tracing solution. You can use them individually or combine them for monitoring.
 
 <Tabs>
   <Tab title="OpenAI Tracing">
@@ -172,7 +172,7 @@ Agency Swarm uses Langchain callbacks to connect with third party observability 
 
 ## Supported Observability Platforms
 
-When it comes to choosing your observability platform, there are a few options. You can use one or multiple trackers simultaneously for comprehensive monitoring:
+When it comes to choosing your observability platform, there are a few options. You can use one or multiple trackers simultaneously for monitoring:
 
 <CardGroup cols={2}>
   <Card title="Langfuse" icon="chart-line" href="#getting-started">
@@ -191,7 +191,7 @@ When it comes to choosing your observability platform, there are a few options. 
 
 ## Getting Started
 
-We currently recommend [**Langfuse**](https://langfuse.com/) because it is fully open source, easy to use, and offers the most comprehensive set of features and support. You can also combine it with other trackers for enhanced observability.
+We currently recommend [**Langfuse**](https://langfuse.com/) because it is fully open source, easy to use, and offers a wide set of features and support. You can also combine it with other trackers for additional observability.
 
 ![Langfuse dashboard](/images/observability-langfuse.png)
 
@@ -296,7 +296,7 @@ We currently recommend [**Langfuse**](https://langfuse.com/) because it is fully
 
 ## How It Works
 
-Agency Swarm uses a simple but powerful tracking system that captures every interaction in your agent's lifecycle:
+Agency Swarm uses a simple tracking system that captures every interaction in your agent's lifecycle:
 
 1. **Event Tracking**: Every message, tool call, and error is automatically tracked with unique IDs and timestamps.
 2. **Hierarchical Structure**: Events are organized in a tree structure, showing how different parts of your agent interact.

--- a/docs/additional-features/output-validation.mdx
+++ b/docs/additional-features/output-validation.mdx
@@ -177,7 +177,7 @@ class User(BaseTool):
 
 ### LLM Validator
 
-The `llm_validator` is a powerful way to validate outputs against specified natural language rules.
+The `llm_validator` validates outputs against specified natural language rules.
 
 **Example:**
 
@@ -202,5 +202,5 @@ In this example, the `llm_validator` will throw an error if the message is not r
 Since `llm_validator` uses LLMs for validation, it may incur additional costs and latency due to extra API calls. Use it for fields that require complex validation beyond simple checks.
 </Note>
 
-By combining all the validators described above, you can create robust validation logic to ensure your agents and tools perform reliably.
+By combining all the validators described above, you can create validation logic to ensure your agents and tools perform reliably.
 

--- a/docs/core-framework/agents/overview.mdx
+++ b/docs/core-framework/agents/overview.mdx
@@ -34,7 +34,7 @@ Agents are the core building blocks of the Agency Swarm framework. Each agent is
 <Tabs defaultValue="v1.x">
 <Tab title="v1.x">
 
-In the latest version, agents are built on top of the `agents` SDK with enhanced capabilities for multi-agent collaboration within an `Agency`. The agent class provides improved context management, async execution, and streamlined tool integration.
+In the latest version, agents are built on top of the `agents` SDK to support multi-agent collaboration within an `Agency`. The agent class provides context management, async execution, and streamlined tool integration.
 
 ## Agent Parameters
 

--- a/examples/custom_send_message.py
+++ b/examples/custom_send_message.py
@@ -77,7 +77,7 @@ def analyze_performance() -> str:
     return "Performance analysis complete. 23% efficiency gain possible."
 
 
-# Coordinator with enhanced SendMessage
+# Coordinator with custom SendMessage
 coordinator = Agent(
     name="Coordinator",
     description="Project coordinator who delegates analysis tasks",
@@ -89,7 +89,7 @@ coordinator = Agent(
         "complete, word-for-word response text in your final output. Do not summarize, "
         "paraphrase, or omit any details from their responses."
     ),
-    send_message_tool_class=SendMessageWithContext,  # Enhanced communication for this agent only
+    send_message_tool_class=SendMessageWithContext,  # Custom communication for this agent only
     model_settings=ModelSettings(temperature=0.0),
 )
 
@@ -153,7 +153,7 @@ def print_send_message_args(agency, agent_name: str) -> None:
 
 
 async def main():
-    """Demonstrate key decisions being passed via enhanced SendMessage."""
+    """Demonstrate key decisions being passed via custom SendMessage."""
     print("\n=== SendMessageWithContext Key Decisions Demo ===")
 
     # Turn 1: Initial discussion

--- a/src/agency_swarm/integrations/fastapi.py
+++ b/src/agency_swarm/integrations/fastapi.py
@@ -36,11 +36,11 @@ def run_fastapi(
     host, port, app_token_env, return_app, cors_origins :
         Standard FastAPI configuration options.
     enable_logging : bool
-        Enable enhanced logging with request tracking and file logging.
+        Enable request tracking and file logging.
         When enabled, adds middleware to track requests and allows conditional
         file logging based on 'x-agency-log-id' header.
     logs_dir : str
-        Directory to store log files when enhanced logging is enabled.
+        Directory to store log files when logging is enabled.
         Defaults to 'activity-logs'.
     """
     if (agencies is None or len(agencies) == 0) and (tools is None or len(tools) == 0):
@@ -78,7 +78,7 @@ def run_fastapi(
 
     app = FastAPI()
 
-    # Setup enhanced logging if enabled
+    # Setup logging if enabled
     if enable_logging:
         setup_enhanced_logging(logs_dir)
         app.add_middleware(RequestTracker)
@@ -152,7 +152,7 @@ def run_fastapi(
 
     app.add_exception_handler(Exception, exception_handler)
 
-    # Add get_logs endpoint if enhanced logging is enabled
+    # Add get_logs endpoint if logging is enabled
     if enable_logging:
         app.add_api_route("/get_logs", make_logs_endpoint(LogRequest, logs_dir, verify_token), methods=["POST"])
         endpoints.append("/get_logs")

--- a/src/agency_swarm/tools/base_tool.py
+++ b/src/agency_swarm/tools/base_tool.py
@@ -2,7 +2,7 @@
 This module provides the BaseTool class for creating Pydantic-based tools in Agency Swarm.
 
 BaseTool is an alternative to @function_tool decorators, offering explicit field definitions,
-model validators, and Pydantic's powerful validation capabilities. Both BaseTool and @function_tool
+model validators, and Pydantic's validation features. Both BaseTool and @function_tool
 are fully supported approaches for tool creation.
 """
 

--- a/tests/test_agent_modules/test_agent_file_manager.py
+++ b/tests/test_agent_modules/test_agent_file_manager.py
@@ -2,7 +2,7 @@
 Tests for agency_swarm.agent.file_manager module.
 
 Focuses on testing the AgentFileManager class functionality
-to achieve comprehensive coverage of error handling and edge cases.
+to cover error handling and edge cases.
 """
 
 import os


### PR DESCRIPTION
## Summary
- trim marketing language from README and docs
- simplify comments in example and FastAPI helper
- clean verbose wording in BaseTool and tests

## Testing
- `make ci` *(fails: openai.OpenAIError: The api_key client option must be set)*
- `uv run pytest tests/integration/ -v` *(fails: api_key client option must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fda439908323ad72d0a8aaf98f07