### PR TITLE
docs: remove inflated wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ def test_my_tool_example():
 
 ---
 
-Thank you for contributing to Agency Swarm! Your efforts help us build a more robust and versatile framework.
+Thank you for contributing to Agency Swarm! Your efforts help improve the framework.
 
 1. **Install Test Dependencies**
 
@@ -150,4 +150,4 @@ class AgentName(Agent):
 
 ---
 
-Thank you for contributing to Agency Swarm! Your efforts help us build a more robust and versatile framework.
+Thank you for contributing to Agency Swarm! Your efforts help improve the framework.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This framework continues the original vision of Arsenii Shatokhin (aka VRSEN) to
 - **Type-Safe Tools**: Develop tools using Pydantic models for automatic argument validation, compatible with the OpenAI Agents SDK's `FunctionTool` format.
 - **Orchestrated Agent Communication**: Agents communicate via a dedicated `send_message` tool, with interactions governed by explicit `communication_flows` (directional) defined on the `Agency`.
 - **Flexible State Persistence**: Manage conversation history by providing `load_threads_callback` and `save_threads_callback` functions to the `Agency`. This allows for loading and saving conversation threads to external storage, enabling persistence across sessions.
-- **Multi-Agent Orchestration**: Build agent workflows by leveraging the OpenAI Agents SDK foundation, enhanced by Agency Swarm's structured orchestration layer.
+- **Multi-Agent Orchestration**: Build agent workflows using the OpenAI Agents SDK foundation and Agency Swarm's orchestration layer.
 - **Production-Ready Focus**: Built for reliability and designed for easy deployment in real-world environments.
 
 ## Installation

--- a/docs/additional-features/custom-communication-flows/common-use-cases.mdx
+++ b/docs/additional-features/custom-communication-flows/common-use-cases.mdx
@@ -206,7 +206,7 @@ class SendMessageAPI(SendMessage):
         return response.json()["message"]
 ```
 
-This is very powerful, as you can even allow your agents to collaborate with agents outside your system. More on this is coming soon!
+This approach lets your agents collaborate with agents outside your system. More on this is coming soon!
 
 **After implementing your own `SendMessage` tool**, simply pass it into the `send_message_tool_class` parameter when initializing the `Agency` class:
 

--- a/docs/additional-features/few-shot-examples.mdx
+++ b/docs/additional-features/few-shot-examples.mdx
@@ -5,7 +5,7 @@ icon: "clone"
 ---
 
 
-**Few-shot prompting** is a powerful technique where you provide a small number of sample interactions (typically 2 to 5) to guide your agent's behavior. This method helps the agent understand the desired output format and task requirements by learning from the given examples, thereby improving performance without writing extensive instructions.
+**Few-shot prompting** is an effective technique where you provide a small number of sample interactions (typically 2 to 5) to guide your agent's behavior. This method helps the agent understand the desired output format and task requirements by learning from the given examples, thereby improving performance without writing extensive instructions.
 
 ## Crafting Effective Examples
 

--- a/docs/contributing/contributing.mdx
+++ b/docs/contributing/contributing.mdx
@@ -64,7 +64,7 @@ pytest
 </Step>
 
 <Step title="Check Test Coverage" icon="chart-bar" iconType="solid">
-Check the test coverage to ensure comprehensive testing.
+Check the test coverage to ensure full testing.
 
 ```bash
 pytest --cov=agency_swarm tests/

--- a/docs/core-framework/agents/built-in-tools.mdx
+++ b/docs/core-framework/agents/built-in-tools.mdx
@@ -6,7 +6,7 @@ icon: "wrench"
 
 <Tabs defaultValue="v1.x">
 <Tab title="v1.x">
-In the latest version, Agency Swarm leverages tools from the [agents SDK](https://openai.github.io/openai-agents-python/ref/tool/) instead of providing its own built-in tools. This provides access to a comprehensive set of production-ready tools maintained by OpenAI.
+In the latest version, Agency Swarm leverages tools from the [agents SDK](https://openai.github.io/openai-agents-python/ref/tool/) instead of providing its own built-in tools. This provides access to a set of production-ready tools maintained by OpenAI.
 
 ## Available Tools
 

--- a/docs/core-framework/tools/overview.mdx
+++ b/docs/core-framework/tools/overview.mdx
@@ -52,7 +52,7 @@ Below are some more examples of tools:
 
 By themselves, each of these tools is not very useful, however in combination with each other, they allow agents to perform a much wider range of tasks.
 
-For example, `FileWriter` tool by itself can allow the developer agent to write code, however, in combination with the `CommandExecutor` tool, it can also run and test its own code, which instantly makes it more powerful. (We'll cover the key characteristics of tools in a bit.)
+For example, the `FileWriter` tool by itself lets the developer agent write code, but in combination with the `CommandExecutor` tool, it can also run and test its own code. (We'll cover the key characteristics of tools in a bit.)
 </Tip>
 **At a low level, tools are essentially just code.**
 

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -5,7 +5,7 @@
 """
 Agency Swarm Examples
 
-This package contains comprehensive examples demonstrating various Agency Swarm capabilities:
+This package contains examples demonstrating various Agency Swarm capabilities:
 
 - Multi-agent communication and coordination patterns
 - File processing, vision analysis, and content handling

--- a/examples/fastapi_integration/server.py
+++ b/examples/fastapi_integration/server.py
@@ -49,8 +49,8 @@ def create_agency(load_threads_callback=None):
     agent2 = Agent(
         name="ExampleAgent2",
         description=(
-            "A helpful and knowledgeable assistant that provides "
-            "comprehensive support and guidance across various domains."
+            "A helpful and knowledgeable assistant that provides support "
+            "and guidance across various domains."
         ),
         instructions="You are a helpful assistant. Use the ExampleTool when asked to greet someone.",
         tools=[ExampleTool],

--- a/src/agency_swarm/context.py
+++ b/src/agency_swarm/context.py
@@ -38,7 +38,7 @@ class MasterContext:
     def __post_init__(self):
         """Basic validation after initialization."""
         # Runtime checks are limited due to forward references.
-        # More robust validation occurs in Agency during context creation.
+        # Additional validation occurs in Agency during context creation.
         # Thread manager validation is done at creation time in Agency
         if not isinstance(self.agents, dict):
             raise TypeError("MasterContext 'agents' must be a dictionary.")


### PR DESCRIPTION
## Summary
- trim exaggerated wording across docs and examples
- clarify orchestration bullet in README
- tidy validation comment in MasterContext

## Testing
- `make ci`
- `uv run pytest tests/integration/ -v` *(fails: KeyboardInterrupt during run)*

------
https://chatgpt.com/codex/tasks/task_e_68b5043182f4832396993cc8be8b5e93