### PR TITLE
guardrails: improve input-guardrail streaming handling and execution …

### DIFF
--- a/examples/guardrails.py
+++ b/examples/guardrails.py
@@ -23,8 +23,8 @@ logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 
 
 # Require user requests to be explicitly scoped as a Support request
-@input_guardrail(name="RequireTaskPrefix")
-async def require_task_prefix(
+@input_guardrail(name="RequireSupportPrefix")
+async def require_support_prefix(
     context: RunContextWrapper, agent: Agent, user_input: str | list[str]
 ) -> GuardrailFunctionOutput:
     """Trip if the latest user message(s) do not begin with "Support:".
@@ -76,7 +76,7 @@ agent = Agent(
     description="Customer support assistant",
     model="gpt-4.1",
     output_guardrails=[forbid_email_output],
-    input_guardrails=[require_task_prefix],
+    input_guardrails=[require_support_prefix],
     validation_attempts=1,  # set to 0 for immediate fail-fast behavior
     return_input_guardrail_errors=True,  # set to False to return an exception when the input guardrail is triggered
 )

--- a/src/agency_swarm/tools/send_message.py
+++ b/src/agency_swarm/tools/send_message.py
@@ -351,7 +351,11 @@ class SendMessage(FunctionTool):
                 if tool_calls_seen:
                     logger.info(f"Sub-agent '{recipient_name_for_call}' executed tools: {tool_calls_seen}")
 
-                response = type("StreamedResponse", (), {"final_output": final_output_text})()
+                logger.info(
+                    f"Received response via tool '{self.name}' from '{recipient_name_for_call}': "
+                    f'"{final_output_text[:50]}..."'
+                )
+                return final_output_text
             else:
                 logger.debug(f"Calling target agent '{recipient_name_for_call}'.get_response...")
 
@@ -393,7 +397,8 @@ class SendMessage(FunctionTool):
                 f"Input guardrail triggered during sub-call via tool '{self.name}' from "
                 f"'{sender_name_for_call}' to '{recipient_name_for_call}': {message}"
             )
-            return f"Error getting response from the agent: {message}"
+            # Mirror Agent.get_response return mode by returning plain guidance
+            return message
 
         except Exception as e:
             logger.error(


### PR DESCRIPTION
…cleanup\n\n- Persist guidance and optionally emit dedicated input_guardrail_guidance events\n- Avoid cleanup on unprepared context; always restore instructions\n- Make SendMessage return plain text for sub-agent success and guidance on input guardrail\n- Update example to reflect RequireSupportPrefix naming and usage